### PR TITLE
feat: Multi-validator support — Gemini as third validator (S-012)

### DIFF
--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -204,7 +204,7 @@ func Status() error {
 
 func detectTools() map[string]bool {
 	tools := map[string]bool{}
-	for _, tool := range []string{"claude", "codex", "aider", "gh", "docker", "node", "npm", "go"} {
+	for _, tool := range []string{"claude", "codex", "gemini", "aider", "gh", "docker", "node", "npm", "go"} { // Spec: S-012 | Req: B-002
 		_, err := exec.LookPath(tool)
 		tools[tool] = err == nil
 	}

--- a/profiles/sdd-mem/CLAUDE.md
+++ b/profiles/sdd-mem/CLAUDE.md
@@ -9,7 +9,7 @@ Orden de trabajo:
 2. **Contrato antes de implementacion** — las interfaces se derivan de la spec
 3. **Validacion derivada de la spec** — los tests se generan desde la spec cuando TDD aplica; cuando no, se define la estrategia de validacion apropiada
 4. **Codigo derivado** — la implementacion satisface la spec, nada mas
-5. **Verificacion dual** — un agente Opus y Codex validan independientemente el resultado final
+5. **Verificacion multi** — un agente Opus, Codex, y Gemini (si disponibles) validan independientemente el resultado final
 
 Principios core:
 - **Spec = Single Source of Truth**: si el codigo no matchea la spec, el codigo esta mal
@@ -104,7 +104,7 @@ Auto-routing (clasificar intent)
 /execute ──→ Implementar wave por wave
     │
     ▼
-/verify ──→ Verificacion dual: Opus + Codex (si disponible)
+/verify ──→ Verificacion multi: Opus + Codex + Gemini (si disponibles)
 ```
 
 Cada skill gestiona sus propios pasos, validaciones, y gates.
@@ -117,7 +117,7 @@ Cada skill gestiona sus propios pasos, validaciones, y gates.
 | `/spec` | Crear spec formal + plan de implementacion |
 | `/derive-tests` | Generar tests desde spec |
 | `/execute` | Implementar desde spec, wave por wave |
-| `/verify` | Verificacion dual (Opus + Codex si disponible) |
+| `/verify` | Verificacion multi (Opus + Codex + Gemini si disponibles — Gemini es opcional) |
 | `/spec-status` | Dashboard de estado de specs |
 | `/quality-gate` | Validacion post-impl (tests, lint, build, spec coverage) |
 | `/fix` | Diagnosticar bug con spec gap check + Codex second opinion |
@@ -322,7 +322,7 @@ automaticamente encima del profile base al hacer `cvm use` o `cvm pull`.
 - Nunca hacer shotgun debugging
 - **Nunca implementar un feature nuevo sin spec** (excepto trivial; si el usuario pide opt-out, usar SDD-lite como minimo)
 - **Nunca cambiar behavior sin actualizar la spec primero** (excepcion: hotfix urgente con spec post-facto)
-- **Nunca ignorar el resultado de la verificacion** (dual si Codex disponible, single si no)
+- **Nunca ignorar el resultado de la verificacion** (triple si Codex+Gemini disponibles, dual si uno disponible, single si ninguno)
 - **Nunca pasar contenido de archivos inline en prompts de Codex** — Codex tiene acceso al filesystem y a `gh`. Darle paths para que lea, o comandos como `gh pr diff`. Si hay un PR abierto, usarlo. Si no, escribir un manifiesto con paths en `/tmp/` y referenciarlo. Esto aplica a specs, implementaciones, diffs, y cualquier otro contenido.
 
 ## Entorno
@@ -331,4 +331,5 @@ automaticamente encima del profile base al hacer `cvm use` o `cvm pull`.
 - Evitar flags GNU-only como `grep -P`. Usar `grep -E` o perl one-liners
 - Para levantar servicios, usar el script `start.sh` del proyecto si existe
 - Codex disponible via `codex exec` para validacion externa. Verificar con `codex exec "echo ok" 2>/dev/null`, no con `which codex`
-- macOS no tiene GNU `timeout` — los skills NO deben usar `timeout` directamente. Codex se ejecuta sin timeout de shell; si se cuelga, el usuario cancela manualmente
+- Gemini disponible via `gemini -p` para validacion externa (tercer validador opcional). Verificar via `~/.cvm/available-tools.json` (campo `gemini.available`). Gemini tiene acceso al filesystem. Spec: S-012
+- macOS no tiene GNU `timeout` — los skills NO deben usar `timeout` directamente. Codex y Gemini se ejecutan sin timeout de shell; si se cuelgan, el usuario cancela manualmente

--- a/profiles/sdd-mem/hooks/check-tools.sh
+++ b/profiles/sdd-mem/hooks/check-tools.sh
@@ -26,7 +26,8 @@ for tool in codex gemini gh docker node npm go python3 ruff cargo make; do
       fi
     # Spec: S-012 | Req: B-001 | Gemini needs deeper validation: LLM prompt health check
     elif [ "$tool" = "gemini" ]; then
-      if gemini -p "reply with exactly: ok" 2>/dev/null | grep -q "ok"; then
+      gemini_output=$(gemini -p "reply with exactly: ok" 2>/dev/null) && echo "$gemini_output" | grep -q "ok"
+      if [ $? -eq 0 ]; then
         json="$json\"$tool\":{\"available\":true,\"path\":\"$path\",\"verified\":true}"
       else
         json="$json\"$tool\":{\"available\":false,\"path\":\"$path\",\"verified\":false,\"reason\":\"installed but not configured\"}"

--- a/profiles/sdd-mem/hooks/check-tools.sh
+++ b/profiles/sdd-mem/hooks/check-tools.sh
@@ -8,7 +8,7 @@ mkdir -p "$(dirname "$tools_file")"
 json="{"
 first=true
 
-for tool in codex gh docker node npm go python3 ruff cargo make; do
+for tool in codex gemini gh docker node npm go python3 ruff cargo make; do
   if [ "$first" = true ]; then
     first=false
   else
@@ -23,6 +23,13 @@ for tool in codex gh docker node npm go python3 ruff cargo make; do
         json="$json\"$tool\":{\"available\":true,\"path\":\"$path\",\"verified\":true}"
       else
         json="$json\"$tool\":{\"available\":false,\"path\":\"$path\",\"verified\":false,\"reason\":\"installed but not configured (license, auth, or sandbox issue)\"}"
+      fi
+    # Spec: S-012 | Req: B-001 | Gemini needs deeper validation: LLM prompt health check
+    elif [ "$tool" = "gemini" ]; then
+      if gemini -p "reply with exactly: ok" 2>/dev/null | grep -q "ok"; then
+        json="$json\"$tool\":{\"available\":true,\"path\":\"$path\",\"verified\":true}"
+      else
+        json="$json\"$tool\":{\"available\":false,\"path\":\"$path\",\"verified\":false,\"reason\":\"installed but not configured\"}"
       fi
     else
       json="$json\"$tool\":{\"available\":true,\"path\":\"$path\"}"

--- a/profiles/sdd-mem/settings.json
+++ b/profiles/sdd-mem/settings.json
@@ -23,7 +23,8 @@
       "Bash(npm *)",
       "Bash(node *)",
       "Bash(npx *)",
-      "Bash(codex *)"
+      "Bash(codex *)",
+      "Bash(gemini *)"
     ],
     "defaultMode": "default"
   },

--- a/profiles/sdd-mem/skills/fix/SKILL.md
+++ b/profiles/sdd-mem/skills/fix/SKILL.md
@@ -19,11 +19,15 @@ Investigar la causa root:
 2. Buscar en KB: `cvm kb search "<area del bug>"`
 3. Analizar la causa
 
-**Second opinion con Codex (si disponible):**
+**Second opinion con Codex y/o Gemini (si disponibles):**
 
-Verificar disponibilidad: `codex exec "echo ok" 2>/dev/null` (con timeout de 10s).
+<!-- Spec: S-012 | Req: B-005 -->
 
-Si Codex esta disponible, lanzar para diagnostico independiente:
+Verificar disponibilidad:
+- Codex: `codex exec "echo ok" 2>/dev/null`
+- Gemini: leer `~/.cvm/available-tools.json` y verificar `gemini.available == true`
+
+Si Codex esta disponible, lanzar en background para diagnostico independiente:
 
 ```bash
 codex exec -s read-only "Diagnosticar este bug: [descripcion]. Encontrar root cause con archivos y lineas especificas. NO hacer cambios.
@@ -31,14 +35,30 @@ codex exec -s read-only "Diagnosticar este bug: [descripcion]. Encontrar root ca
 Sintoma: [que pasa]
 Esperado: [que deberia pasar]
 
-Reportar: root cause con archivo(s), linea(s), y explicacion de POR QUE ocurre."
+Reportar: root cause con archivo(s), linea(s), y explicacion de POR QUE ocurre." > /tmp/cvm-fix-codex.txt 2>&1 &
+CODEX_PID=$!
 ```
 
-Si Codex fue consultado, comparar hallazgos:
-- Coinciden → alta confianza, proceder
-- Difieren → analizar ambas hipotesis, elegir la mejor fundamentada
+Si Gemini esta disponible, lanzar en background en paralelo:
 
-Gate: DEBE tener una hipotesis clara antes de continuar. No shotgun debugging.
+```bash
+gemini -p "Diagnosticar este bug: [descripcion]. Encontrar root cause con archivos y lineas especificas. NO hacer cambios. Sintoma: [que pasa]. Esperado: [que deberia pasar]. Reportar: root cause con archivo(s), linea(s), y explicacion de POR QUE ocurre." > /tmp/cvm-fix-gemini.txt 2>&1 &
+GEMINI_PID=$!
+```
+
+Esperar resultados:
+```bash
+[ -n "$CODEX_PID" ] && wait $CODEX_PID
+[ -n "$GEMINI_PID" ] && wait $GEMINI_PID
+```
+
+Comparar hallazgos:
+- Codex y Gemini coinciden → alta confianza, proceder
+- Codex y Gemini difieren → presentar ambas hipotesis al usuario para resolucion
+- Solo uno disponible → usar ese resultado
+- Ninguno disponible → proceder con analisis propio
+
+Gate: DEBE tener una hipotesis clara (del conjunto combinado de opiniones) antes de continuar. No shotgun debugging.
 
 ## Paso 4: Spec gap check (nuevo en SDD)
 

--- a/profiles/sdd-mem/skills/fix/SKILL.md
+++ b/profiles/sdd-mem/skills/fix/SKILL.md
@@ -52,6 +52,9 @@ Esperar resultados:
 [ -n "$GEMINI_PID" ] && wait $GEMINI_PID
 ```
 
+Si el output de Codex o Gemini esta vacio o contiene un error: loguear warning, excluir
+ese validador, y proceder con los disponibles. NUNCA bloquear el workflow por un fallo.
+
 Comparar hallazgos:
 - Codex y Gemini coinciden → alta confianza, proceder
 - Codex y Gemini difieren → presentar ambas hipotesis al usuario para resolucion

--- a/profiles/sdd-mem/skills/spec/SKILL.md
+++ b/profiles/sdd-mem/skills/spec/SKILL.md
@@ -88,21 +88,39 @@ Crear o actualizar `specs/REGISTRY.md`:
 Mostrar la spec completa al usuario. Esperar aprobacion antes de continuar.
 Si el usuario pide cambios, iterar hasta que apruebe.
 
-## Paso 3: Validacion externa (si Codex esta disponible)
+## Paso 3: Validacion externa (Codex y/o Gemini si disponibles)
 
-Verificar disponibilidad de Codex: `codex exec "echo ok" 2>/dev/null` (con timeout de 10s).
-Si falla o no responde: Codex no disponible para esta sesion.
+<!-- Spec: S-012 | Req: B-003 -->
 
-**Si disponible**, validar la spec (NUNCA pasar contenido inline — dar el path):
+Verificar disponibilidad de validadores externos:
+- Codex: `codex exec "echo ok" 2>/dev/null`
+- Gemini: leer `~/.cvm/available-tools.json` y verificar `gemini.available == true`
+
+Si ninguno esta disponible: informar al usuario, aprobar solo con su OK.
+
+**Si Codex esta disponible**, lanzar en background (NUNCA pasar contenido inline — dar el path):
 ```bash
-codex exec "Review the spec at specs/<nombre>.spec.md for: 1) ambiguity, 2) gaps, 3) contradictions, 4) testability. Be critical."
+codex exec "Review the spec at specs/<nombre>.spec.md for: 1) ambiguity, 2) gaps, 3) contradictions, 4) testability. Be critical." > /tmp/cvm-spec-codex-review.txt 2>&1 &
+CODEX_PID=$!
 ```
-Codex tiene acceso al filesystem — que lea el archivo directamente.
+
+**Si Gemini esta disponible**, lanzar en background en paralelo:
+```bash
+gemini -p "Review the spec at specs/<nombre>.spec.md for: 1) ambiguity 2) gaps 3) contradictions 4) testability. Be critical. Output a structured review." > /tmp/cvm-spec-gemini-review.txt 2>&1 &
+GEMINI_PID=$!
+```
+
+**Recolectar resultados** (esperar a los procesos que se lanzaron):
+```bash
+# Esperar solo los que se lanzaron
+[ -n "$CODEX_PID" ] && wait $CODEX_PID
+[ -n "$GEMINI_PID" ] && wait $GEMINI_PID
+```
+
+Presentar ambas opiniones al usuario. Si alguno falla: loguear advertencia, continuar con el que este disponible.
 
 - Si hay issues: incorporar, actualizar, mostrar cambios
 - Si pasa: status → approved
-
-**Si no disponible**: informar al usuario, aprobar solo con su OK.
 
 ## Paso 4: Preflight check
 

--- a/profiles/sdd-mem/skills/verify/SKILL.md
+++ b/profiles/sdd-mem/skills/verify/SKILL.md
@@ -84,13 +84,18 @@ GEMINI_PID=$!
 
 Gemini tiene acceso al filesystem. NUNCA copiar contenido de archivos en el prompt.
 
-**Si no disponible**: omitir columna Gemini del reporte.
+**Si no disponible**: mostrar "-" en la columna Gemini del reporte.
 
 **Esperar resultados de background processes:**
 ```bash
 [ -n "$CODEX_PID" ] && wait $CODEX_PID
 [ -n "$GEMINI_PID" ] && wait $GEMINI_PID
 ```
+
+**Manejo de fallos (I-006):** Si el output de Codex o Gemini esta vacio, contiene un error,
+o no tiene verdicts parseables: loguear warning, excluir ese validador de la matriz de
+consenso, y proceder con los validadores restantes. NUNCA bloquear el workflow por un
+validador fallido.
 
 ## Paso 3: Consolidar resultados
 
@@ -127,7 +132,7 @@ Dual Verification: [spec ID] v[version]
 | Requisito | Opus | [Codex|Gemini] | Consenso |
 |-----------|------|----------------|----------|
 | B-001 | MATCH | MATCH | VERIFIED |
-| B-002 | MATCH | MISMATCH | CONCERN |
+| B-002 | MATCH | MISMATCH | REVIEW |
 | E-001 | GAP | GAP | NOT_IMPLEMENTED |
 
 Matriz de consenso con 2 validadores:

--- a/profiles/sdd-mem/skills/verify/SKILL.md
+++ b/profiles/sdd-mem/skills/verify/SKILL.md
@@ -1,4 +1,6 @@
-Verificacion dual: agente Opus + Codex validan independientemente que la implementacion matchea la spec. Se invoca automaticamente despues de implementar. $ARGUMENTS es el path a la spec.
+Verificacion multi: agente Opus + Codex + Gemini validan independientemente que la implementacion matchea la spec. Se invoca automaticamente despues de implementar. $ARGUMENTS es el path a la spec.
+
+<!-- Spec: S-012 | Req: B-004, B-006 -->
 
 ## Paso 1: Cargar artefactos
 
@@ -10,7 +12,9 @@ Leer:
 
 Si falta alguno, reportar y preguntar como proceder.
 
-## Paso 2: Lanzar verificacion dual en paralelo
+## Paso 2: Lanzar verificacion multi en paralelo
+
+Lanzar los tres validadores al mismo tiempo. Opus via Agent tool, Codex y Gemini via bash en background.
 
 ### Verificacion Opus (subagent con model opus, rol verifier)
 
@@ -46,38 +50,92 @@ Si falla o no responde: Codex no disponible para esta sesion.
    # listar los archivos de implementacion, uno por linea
    ```
 
-**Lanzar Codex con referencia a archivos, no contenido inline:**
+**Lanzar Codex en background con referencia a archivos, no contenido inline:**
 
 ```bash
 # Si hay PR abierto:
-codex exec "Verify spec conformance. Read the spec at [path a la spec]. Read the implementation diff with: gh pr diff [number]. For each requirement (B-XXX, E-XXX, I-XXX), state MATCH, MISMATCH (explain), or GAP (not found). Also detect over-engineering (code without spec requirement)."
+codex exec "Verify spec conformance. Read the spec at [path a la spec]. Read the implementation diff with: gh pr diff [number]. For each requirement (B-XXX, E-XXX, I-XXX), state MATCH, MISMATCH (explain), or GAP (not found). Also detect over-engineering (code without spec requirement)." > /tmp/cvm-verify-codex.txt 2>&1 &
+CODEX_PID=$!
 
 # Si no hay PR:
-codex exec "Verify spec conformance. Read the spec at [path a la spec]. Read the implementation files listed in /tmp/cvm-verify-manifest.txt. For each requirement (B-XXX, E-XXX, I-XXX), state MATCH, MISMATCH (explain), or GAP (not found). Also detect over-engineering (code without spec requirement)."
+codex exec "Verify spec conformance. Read the spec at [path a la spec]. Read the implementation files listed in /tmp/cvm-verify-manifest.txt. For each requirement (B-XXX, E-XXX, I-XXX), state MATCH, MISMATCH (explain), or GAP (not found). Also detect over-engineering (code without spec requirement)." > /tmp/cvm-verify-codex.txt 2>&1 &
+CODEX_PID=$!
 ```
 
 **IMPORTANTE**: Codex tiene acceso al filesystem y a `gh`. NUNCA copiar contenido de archivos en el prompt de Codex — siempre darle paths o comandos para que los lea el mismo.
 
-**Si no disponible**: la verificacion es solo Opus (single verify). Informar al usuario que no hay second opinion externa.
+**Si no disponible**: omitir columna Codex del reporte.
+
+### Verificacion Gemini (solo si `gemini` esta disponible) — Spec: S-012 | Req: B-004
+
+Verificar disponibilidad: leer `~/.cvm/available-tools.json` y verificar `gemini.available == true`.
+
+**Si disponible**, lanzar en background en paralelo con Codex (mismo manifiesto, NUNCA contenido inline):
+
+```bash
+# Si hay PR abierto:
+gemini -p "Verify spec conformance. Read the spec at [path a la spec]. Read the implementation diff with: gh pr diff [number]. For each requirement (B-XXX, E-XXX, I-XXX), state MATCH, MISMATCH (explain), or GAP (not found). Be strict." > /tmp/cvm-verify-gemini.txt 2>&1 &
+GEMINI_PID=$!
+
+# Si no hay PR:
+gemini -p "Verify spec conformance. Read the spec at [path a la spec]. Read the implementation files listed in /tmp/cvm-verify-manifest.txt. For each requirement (B-XXX, E-XXX, I-XXX), state MATCH, MISMATCH (explain), or GAP (not found). Be strict." > /tmp/cvm-verify-gemini.txt 2>&1 &
+GEMINI_PID=$!
+```
+
+Gemini tiene acceso al filesystem. NUNCA copiar contenido de archivos en el prompt.
+
+**Si no disponible**: omitir columna Gemini del reporte.
+
+**Esperar resultados de background processes:**
+```bash
+[ -n "$CODEX_PID" ] && wait $CODEX_PID
+[ -n "$GEMINI_PID" ] && wait $GEMINI_PID
+```
 
 ## Paso 3: Consolidar resultados
 
-**Si hubo dual verification (Opus + Codex):**
+<!-- Spec: S-012 | Req: B-006 -->
+
+**Si hubo triple verification (Opus + Codex + Gemini):**
+
+```
+Triple Verification: [spec ID] v[version]
+
+| Requisito | Opus | Codex | Gemini | Veredicto |
+|-----------|------|-------|--------|-----------|
+| B-001 | MATCH | MATCH | MATCH | VERIFIED |
+| B-002 | MATCH | MATCH | MISMATCH | CONCERN (Gemini: "...") |
+| B-003 | MATCH | GAP | - | CONCERN |
+| E-001 | GAP | GAP | GAP | NOT_IMPLEMENTED |
+
+Matriz de consenso con 3 validadores:
+- 3/3 MATCH                  → VERIFIED (alta confianza)
+- 2/3 MATCH + 1 GAP          → VERIFIED (notar el gap)
+- 2/3 MATCH + 1 MISMATCH     → CONCERN (notar razonamiento disidente)
+- 1/3 MATCH                  → REVIEW (requiere revision humana)
+- 0/3 MATCH (todos GAP)      → NOT_IMPLEMENTED
+- 0/3 MATCH (algun MISMATCH) → REVIEW
+
+Resultado: X/Y requisitos VERIFIED
+```
+
+**Si hubo dual verification (Opus + Codex o Opus + Gemini):**
 
 ```
 Dual Verification: [spec ID] v[version]
 
-| Requisito | Opus | Codex | Consenso |
-|-----------|------|-------|----------|
+| Requisito | Opus | [Codex|Gemini] | Consenso |
+|-----------|------|----------------|----------|
 | B-001 | MATCH | MATCH | VERIFIED |
-| B-002 | MATCH | MISMATCH | REVIEW |
-| E-001 | GAP | GAP | NOT IMPLEMENTED |
+| B-002 | MATCH | MISMATCH | CONCERN |
+| E-001 | GAP | GAP | NOT_IMPLEMENTED |
 
-Consenso:
-- VERIFIED: ambos dicen MATCH
-- REVIEW: discrepancia entre Opus y Codex — investigar
-- NOT IMPLEMENTED: ambos detectan gap
-- CONCERN: uno detecta issue, el otro no
+Matriz de consenso con 2 validadores:
+- 2/2 MATCH              → VERIFIED
+- 1 MATCH + 1 GAP        → CONCERN
+- 1 MATCH + 1 MISMATCH   → REVIEW (requiere revision humana)
+- 0/2 MATCH (ambos GAP)  → NOT_IMPLEMENTED
+- 0/2 MATCH (algun MISMATCH) → REVIEW
 
 Resultado: X/Y requisitos VERIFIED
 ```
@@ -85,12 +143,12 @@ Resultado: X/Y requisitos VERIFIED
 **Si fue single verification (solo Opus):**
 ```
 Single Verification: [spec ID] v[version]
-(Codex no disponible — sin second opinion externa)
+(Sin second opinion externa disponible)
 
 | Requisito | Opus | Veredicto |
 |-----------|------|-----------|
 | B-001 | MATCH | VERIFIED |
-| E-001 | GAP | NOT IMPLEMENTED |
+| E-001 | GAP | NOT_IMPLEMENTED |
 
 Resultado: X/Y requisitos VERIFIED
 ```
@@ -121,12 +179,15 @@ Si NOT VERIFIED: listar issues pendientes para el usuario.
 
 ## MUST DO
 - Verificar CADA requisito — no samplear
-- Lanzar Opus y Codex en paralelo
+- Lanzar Opus, Codex, y Gemini en paralelo (los que esten disponibles)
 - Resolver TODAS las discrepancias antes de dar veredicto
 - Reportar mismatches con ubicacion exacta
+- Incluir columna Gemini en la tabla (mostrar "-" si no disponible)
 
 ## MUST NOT DO
 - NO aprobar si hay mismatches sin resolver
-- NO ignorar el resultado de Codex
+- NO ignorar el resultado de Codex (si disponible)
+- NO ignorar el resultado de Gemini (si disponible)
 - NO ignorar el resultado de Opus
 - NO corregir la spec — solo reportar (el usuario decide)
+- NO bloquear el workflow si Gemini no esta disponible — es opcional (Spec: S-012 | Req: I-001)


### PR DESCRIPTION
## Summary

Implements spec S-012 — adds Gemini CLI as an optional third validator alongside Opus and Codex across the SDD verification pipeline.

- **Wave 1 — Tool detection**: `check-tools.sh` detects `gemini` with a real LLM health check (`gemini -p "reply with exactly: ok"`); `lifecycle.go` adds `"gemini"` to the tools list; `settings.json` adds `Bash(gemini *)` permission
- **Wave 2 — Spec validation**: `/spec` skill runs Codex and Gemini in parallel (background processes) for spec review
- **Wave 3 — Triple verify**: `/verify` upgrades from dual to multi-validator with a full 3-validator consensus matrix (3/3, 2/3+gap, 2/3+mismatch, 1/3, 0/3 cases); falls back gracefully to dual or single verify when validators are absent
- **Wave 4 — Fix + docs**: `/fix` skill adds Gemini as parallel diagnostic opinion; `CLAUDE.md` updated from "verificacion dual" to "verificacion multi" throughout

Gemini is always optional — all workflows continue to work without it (invariant I-001). No timeouts added (macOS constraint, same as Codex).

Closes #4

## Test plan

- [ ] `cvm use sdd-mem` → verify `available-tools.json` contains `gemini` entry (available or not)
- [ ] `cvm lifecycle start` → verify tools list includes `gemini` when installed
- [ ] `/spec` on a new spec → verify Codex and/or Gemini opinions are collected and presented
- [ ] `/verify` with all 3 validators available → verify triple consensus table renders correctly
- [ ] `/verify` with only Opus available → verify single verify still works (no regression)
- [ ] `/fix` with Gemini available → verify both Codex and Gemini opinions appear in diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)