### PR TITLE
feat(S-019): tag taxonomy + dashboard tag visualization

### DIFF
--- a/cmd/kb.go
+++ b/cmd/kb.go
@@ -47,7 +47,7 @@ var kbPutCmd = &cobra.Command{
 			if err := kb.ValidateType(typeTag); err != nil {
 				return err
 			}
-			tags = append(tags, "type:"+typeTag)
+			tags = append(tags, typeTag)
 		}
 		// If session-id provided, skip dedup and write directly with session linking.
 		// Otherwise use dedup as before. Spec: S-017 | Req: C-010, B-015
@@ -352,8 +352,79 @@ var kbCompactCmd = &cobra.Command{
 	},
 }
 
+// Spec: S-019 | Req: C-005
+var kbMigrateTagsCmd = &cobra.Command{
+	Use:   "migrate-tags",
+	Short: "Clean up KB: remove entries without a type tag and session-buffer residues",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		scope, projectPath := kbScope(cmd)
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		b, err := kb.NewBackend(scope, projectPath)
+		if err != nil {
+			return err
+		}
+		defer b.Close()
+
+		entries, err := b.List("")
+		if err != nil {
+			return err
+		}
+
+		deletedUntyped := 0
+		deletedBuffer := 0
+
+		for _, e := range entries {
+			// Delete session-buffer-* residues
+			if strings.HasPrefix(e.Key, "session-buffer-") {
+				if dryRun {
+					fmt.Printf("[dry-run] would delete session-buffer entry: %s\n", e.Key)
+				} else {
+					if err := b.Remove(e.Key); err != nil {
+						fmt.Printf("warning: failed to delete %s: %v\n", e.Key, err)
+						continue
+					}
+				}
+				deletedBuffer++
+				continue
+			}
+
+			// Check if entry has at least one type tag
+			hasType := false
+			for _, tag := range e.Tags {
+				if kb.ClassifyTag(tag) == "type" {
+					hasType = true
+					break
+				}
+			}
+			if !hasType {
+				if dryRun {
+					fmt.Printf("[dry-run] would delete untyped entry: %s (tags: %v)\n", e.Key, e.Tags)
+				} else {
+					if err := b.Remove(e.Key); err != nil {
+						fmt.Printf("warning: failed to delete %s: %v\n", e.Key, err)
+						continue
+					}
+				}
+				deletedUntyped++
+			}
+		}
+
+		if deletedUntyped == 0 && deletedBuffer == 0 {
+			fmt.Println("No changes needed")
+		} else {
+			prefix := ""
+			if dryRun {
+				prefix = "[dry-run] "
+			}
+			fmt.Printf("%sDeleted %d untyped entries, removed %d session-buffer entries\n", prefix, deletedUntyped, deletedBuffer)
+		}
+		return nil
+	},
+}
+
 func init() {
-	for _, c := range []*cobra.Command{kbPutCmd, kbLsCmd, kbRmCmd, kbShowCmd, kbEnableCmd, kbDisableCmd, kbSearchCmd, kbCleanCmd, kbTimelineCmd, kbStatsCmd, kbCompactCmd} {
+	for _, c := range []*cobra.Command{kbPutCmd, kbLsCmd, kbRmCmd, kbShowCmd, kbEnableCmd, kbDisableCmd, kbSearchCmd, kbCleanCmd, kbTimelineCmd, kbStatsCmd, kbCompactCmd, kbMigrateTagsCmd} {
 		c.Flags().Bool("local", false, "Use local KB (default: global)")
 	}
 	kbPutCmd.Flags().String("body", "", "Entry body content")
@@ -383,4 +454,6 @@ func init() {
 	kbCmd.AddCommand(kbTimelineCmd)
 	kbCmd.AddCommand(kbStatsCmd)
 	kbCmd.AddCommand(kbCompactCmd)
+	kbMigrateTagsCmd.Flags().Bool("dry-run", false, "Print changes without applying them")
+	kbCmd.AddCommand(kbMigrateTagsCmd)
 }

--- a/cmd/kb.go
+++ b/cmd/kb.go
@@ -373,6 +373,7 @@ var kbMigrateTagsCmd = &cobra.Command{
 
 		deletedUntyped := 0
 		deletedBuffer := 0
+		failures := 0
 
 		for _, e := range entries {
 			// Delete session-buffer-* residues
@@ -382,6 +383,7 @@ var kbMigrateTagsCmd = &cobra.Command{
 				} else {
 					if err := b.Remove(e.Key); err != nil {
 						fmt.Printf("warning: failed to delete %s: %v\n", e.Key, err)
+						failures++
 						continue
 					}
 				}
@@ -403,6 +405,7 @@ var kbMigrateTagsCmd = &cobra.Command{
 				} else {
 					if err := b.Remove(e.Key); err != nil {
 						fmt.Printf("warning: failed to delete %s: %v\n", e.Key, err)
+						failures++
 						continue
 					}
 				}
@@ -410,14 +413,18 @@ var kbMigrateTagsCmd = &cobra.Command{
 			}
 		}
 
-		if deletedUntyped == 0 && deletedBuffer == 0 {
+		if deletedUntyped == 0 && deletedBuffer == 0 && failures == 0 {
 			fmt.Println("No changes needed")
 		} else {
 			prefix := ""
 			if dryRun {
 				prefix = "[dry-run] "
 			}
-			fmt.Printf("%sDeleted %d untyped entries, removed %d session-buffer entries\n", prefix, deletedUntyped, deletedBuffer)
+			fmt.Printf("%sDeleted %d untyped entries, removed %d session-buffer entries", prefix, deletedUntyped, deletedBuffer)
+			if failures > 0 {
+				fmt.Printf(" (%d failures)", failures)
+			}
+			fmt.Println()
 		}
 		return nil
 	},

--- a/internal/dashboard/api.go
+++ b/internal/dashboard/api.go
@@ -822,8 +822,7 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 		entries, err := s.globalBack.List("")
 		if err == nil {
 			for _, e := range entries {
-				isLegacySummary := strings.HasPrefix(e.Key, "session-summary-") ||
-					strings.HasPrefix(e.Key, "session-")
+				isLegacySummary := strings.HasPrefix(e.Key, "session-")
 				if !isLegacySummary {
 					continue
 				}

--- a/internal/dashboard/api.go
+++ b/internal/dashboard/api.go
@@ -823,8 +823,7 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			for _, e := range entries {
 				isLegacySummary := strings.HasPrefix(e.Key, "session-summary-") ||
-					(strings.HasPrefix(e.Key, "session-") &&
-						!strings.HasPrefix(e.Key, "session-buffer-"))
+					strings.HasPrefix(e.Key, "session-")
 				if !isLegacySummary {
 					continue
 				}
@@ -899,12 +898,14 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 
 // --- Stats ---
 
+// Spec: S-019 | Req: C-002
 type scopeStatsJSON struct {
 	Total       int            `json:"total"`
 	Enabled     int            `json:"enabled"`
 	Stale       int            `json:"stale"`
 	TotalTokens int            `json:"total_tokens"`
-	ByTag       map[string]int `json:"by_tag"`
+	ByType      map[string]int `json:"by_type"`
+	ByTopic     map[string]int `json:"by_topic"`
 }
 
 type statsResponse struct {
@@ -921,8 +922,9 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Spec: S-019 | Req: C-002
 	buildScopeStats := func(b kb.Backend) scopeStatsJSON {
-		zero := scopeStatsJSON{ByTag: map[string]int{}}
+		zero := scopeStatsJSON{ByType: map[string]int{}, ByTopic: map[string]int{}}
 		if b == nil {
 			return zero
 		}
@@ -931,13 +933,19 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			return zero
 		}
 
-		// Build by_tag from all entries
-		byTag := make(map[string]int)
+		byType := make(map[string]int)
+		byTopic := make(map[string]int)
 		entries, err := b.List("")
 		if err == nil {
 			for _, e := range entries {
 				for _, t := range e.Tags {
-					byTag[t]++
+					switch kb.ClassifyTag(t) {
+					case "type":
+						byType[t]++
+					case "topic":
+						byTopic[t]++
+					// "internal" tags are excluded
+					}
 				}
 			}
 		}
@@ -947,7 +955,8 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			Enabled:     stats.Enabled,
 			Stale:       stats.Stale,
 			TotalTokens: stats.TotalTokens,
-			ByTag:       byTag,
+			ByType:      byType,
+			ByTopic:     byTopic,
 		}
 	}
 

--- a/internal/dashboard/web/static/app.js
+++ b/internal/dashboard/web/static/app.js
@@ -61,18 +61,16 @@ function formatTokens(n) {
 
 // ---- Badge helpers ----
 
+// Spec: S-019 | Req: C-003d
 const TAG_COLORS = {
   learning: 'badge-learning',
   gotcha: 'badge-gotcha',
   decision: 'badge-decision',
   session: 'badge-session',
-  summary: 'badge-summary',
-  'spec-gap': 'badge-spec-gap',
 };
 
 function badgeClass(tag) {
-  const base = tag.replace(/^type:/, '');
-  return TAG_COLORS[base] || 'badge-default';
+  return TAG_COLORS[tag] || 'badge-default';
 }
 
 function renderBadge(tag) {
@@ -559,17 +557,52 @@ function renderScopeStats(scope, stats) {
   if (staleEl) staleEl.textContent = stats.stale || 0;
   if (tokensEl) tokensEl.textContent = formatTokens(stats.total_tokens || 0);
 
-  if (tagsEl && stats.by_tag) {
+  // Spec: S-019 | Req: C-003, C-004
+  if (tagsEl) {
     tagsEl.innerHTML = '';
-    const sorted = Object.entries(stats.by_tag).sort((a, b) => b[1] - a[1]);
-    sorted.forEach(([tag, count]) => {
-      const row = el('div', 'tag-row');
-      row.appendChild(el('span', 'tag-name', tag));
-      row.appendChild(el('span', 'tag-count', String(count)));
-      tagsEl.appendChild(row);
-    });
-    if (!sorted.length) tagsEl.appendChild(el('span', '', 'No tags'));
+    const byType = stats.by_type || {};
+    const byTopic = stats.by_topic || {};
+    const sortedTypes = Object.entries(byType).sort((a, b) => b[1] - a[1]);
+    const sortedTopics = Object.entries(byTopic).sort((a, b) => b[1] - a[1]);
+
+    if (sortedTypes.length) {
+      tagsEl.appendChild(el('div', 'tag-section-title', 'Types'));
+      sortedTypes.forEach(([tag, count]) => {
+        const row = el('div', 'tag-row tag-row-clickable');
+        const badge = el('span', `badge ${badgeClass(tag)}`, tag);
+        row.appendChild(badge);
+        row.appendChild(el('span', 'tag-count', String(count)));
+        row.addEventListener('click', () => filterByTag(tag));
+        tagsEl.appendChild(row);
+      });
+    }
+    if (sortedTopics.length) {
+      tagsEl.appendChild(el('div', 'tag-section-title', 'Topics'));
+      sortedTopics.forEach(([tag, count]) => {
+        const row = el('div', 'tag-row tag-row-clickable');
+        row.appendChild(el('span', 'tag-name', tag));
+        row.appendChild(el('span', 'tag-count', String(count)));
+        row.addEventListener('click', () => filterByTag(tag));
+        tagsEl.appendChild(row);
+      });
+    }
+    if (!sortedTypes.length && !sortedTopics.length) {
+      tagsEl.appendChild(el('span', '', 'No tags'));
+    }
   }
+}
+
+// Spec: S-019 | Req: C-004 — click tag to filter in Browser
+function filterByTag(tag) {
+  window.location.hash = '#knowledge';
+  setTimeout(() => {
+    const tagInput = $('#knowledge-tag');
+    if (tagInput) {
+      tagInput.value = tag;
+      state.knowledgeTag = tag;
+      loadKnowledge();
+    }
+  }, 50);
 }
 
 // ---- Stats auto-refresh ----

--- a/internal/dashboard/web/static/app.js
+++ b/internal/dashboard/web/static/app.js
@@ -83,6 +83,16 @@ function renderScopeBadge(scope) {
   return el('span', `badge badge-${scope}`, scope);
 }
 
+// ---- URL hash helpers ----
+
+// Spec: S-019 | Req: C-004b — parse tag from URL hash (e.g. #knowledge?tag=learning)
+function parseHash() {
+  const raw = window.location.hash.replace('#', '') || 'sessions';
+  const [tab, qs] = raw.split('?');
+  const params = new URLSearchParams(qs || '');
+  return { tab: tab || 'sessions', tag: params.get('tag') || '' };
+}
+
 // ---- Tab navigation ----
 
 function initTabs() {
@@ -93,12 +103,15 @@ function initTabs() {
   });
 
   window.addEventListener('hashchange', () => {
-    const hash = window.location.hash.replace('#', '') || 'sessions';
-    if (hash !== state.tab) switchTab(hash, false);
+    const parsed = parseHash();
+    if (parsed.tab !== state.tab) switchTab(parsed.tab, false);
   });
 
-  const initial = window.location.hash.replace('#', '') || 'sessions';
-  switchTab(initial, false);
+  const parsed = parseHash();
+  if (parsed.tag) {
+    state.knowledgeTag = parsed.tag;
+  }
+  switchTab(parsed.tab, false);
 }
 
 function switchTab(tab, updateHash = true) {
@@ -427,6 +440,8 @@ function initKnowledge() {
 
   const tagInput = $('#knowledge-tag');
   if (tagInput) {
+    // Restore tag from URL or state on init
+    if (state.knowledgeTag) tagInput.value = state.knowledgeTag;
     tagInput.addEventListener('change', () => {
       state.knowledgeTag = tagInput.value;
       loadKnowledge();
@@ -580,7 +595,7 @@ function renderScopeStats(scope, stats) {
       tagsEl.appendChild(el('div', 'tag-section-title', 'Topics'));
       sortedTopics.forEach(([tag, count]) => {
         const row = el('div', 'tag-row tag-row-clickable');
-        row.appendChild(el('span', 'tag-name', tag));
+        row.appendChild(el('span', 'badge badge-default', tag));
         row.appendChild(el('span', 'tag-count', String(count)));
         row.addEventListener('click', () => filterByTag(tag));
         tagsEl.appendChild(row);
@@ -592,17 +607,12 @@ function renderScopeStats(scope, stats) {
   }
 }
 
-// Spec: S-019 | Req: C-004 — click tag to filter in Browser
+// Spec: S-019 | Req: C-004 — click tag to filter in Knowledge tab
 function filterByTag(tag) {
-  window.location.hash = '#knowledge';
-  setTimeout(() => {
-    const tagInput = $('#knowledge-tag');
-    if (tagInput) {
-      tagInput.value = tag;
-      state.knowledgeTag = tag;
-      loadKnowledge();
-    }
-  }, 50);
+  state.knowledgeTag = tag;
+  const tagInput = $('#knowledge-tag');
+  if (tagInput) tagInput.value = tag;
+  window.location.hash = `#knowledge?tag=${encodeURIComponent(tag)}`;
 }
 
 // ---- Stats auto-refresh ----

--- a/internal/dashboard/web/static/style.css
+++ b/internal/dashboard/web/static/style.css
@@ -232,8 +232,6 @@ main {
 .badge-gotcha     { background: var(--badge-gotcha);    color: var(--orange); }
 .badge-decision   { background: var(--badge-decision);  color: var(--green); }
 .badge-session    { background: var(--badge-session);   color: var(--purple); }
-.badge-summary    { background: #2a2a3a; color: var(--pink); }
-.badge-spec-gap   { background: #3a2a1a; color: var(--yellow); }
 .badge-default    { background: var(--badge-default);   color: var(--muted); }
 .badge-global     { background: #1a2a1a; color: var(--teal); }
 .badge-local      { background: #2a1a2a; color: var(--pink); }
@@ -409,6 +407,16 @@ main {
   overflow-y: auto;
 }
 
+/* Spec: S-019 | Req: C-003, C-004 */
+.tag-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 8px;
+  margin-bottom: 2px;
+}
 .tag-row {
   display: flex;
   justify-content: space-between;
@@ -416,6 +424,8 @@ main {
   padding: 2px 0;
   font-size: 12px;
 }
+.tag-row-clickable { cursor: pointer; border-radius: 4px; padding: 2px 4px; }
+.tag-row-clickable:hover { background: var(--surface); }
 .tag-row .tag-name { color: var(--muted); font-family: var(--font-mono); }
 .tag-row .tag-count {
   font-family: var(--font-mono);

--- a/internal/kb/flat.go
+++ b/internal/kb/flat.go
@@ -156,7 +156,7 @@ func (f *FlatBackend) Search(query string, opts SearchOptions) ([]SearchResult, 
 		if opts.TypeTag != "" {
 			found := false
 			for _, t := range e.Tags {
-				if t == "type:"+opts.TypeTag {
+				if t == opts.TypeTag {
 					found = true
 					break
 				}

--- a/internal/kb/kb.go
+++ b/internal/kb/kb.go
@@ -24,6 +24,31 @@ func ValidateType(t string) error {
 	return fmt.Errorf("invalid type %q: must be one of %s", t, strings.Join(ValidTypes, ", "))
 }
 
+// Spec: S-019 | Req: B-001, B-002, B-003
+var TypeTags = ValidTypes
+
+var InternalTags = []string{"auto-captured", "session-buffer"}
+
+func ClassifyTag(tag string) string {
+	for _, t := range InternalTags {
+		if tag == t || strings.HasPrefix(tag, t+"-") {
+			return "internal"
+		}
+	}
+	if strings.HasPrefix(tag, "type:") {
+		return "internal"
+	}
+	if matched, _ := filepath.Match("s[0-9][0-9][0-9]", tag); matched {
+		return "internal"
+	}
+	for _, t := range TypeTags {
+		if tag == t {
+			return "type"
+		}
+	}
+	return "topic"
+}
+
 // Spec: S-010 | Req: B-009, B-010
 type SearchOptions struct {
 	Tag     string
@@ -330,23 +355,6 @@ func readBody(scope config.Scope, projectPath, key string) (string, error) {
 func bodyHash(body string) string {
 	h := sha256.Sum256([]byte(body))
 	return fmt.Sprintf("%x", h[:8])
-}
-
-// PutWithOptions validates the type tag and calls Put. Delegates through Backend.
-// Spec: S-010 | Req: B-008 | Fix: Backend wiring
-func PutWithOptions(scope config.Scope, projectPath, key, body string, tags []string, typeTag string) error {
-	if typeTag != "" {
-		if err := ValidateType(typeTag); err != nil {
-			return err
-		}
-		tags = append(tags, "type:"+typeTag)
-	}
-	b, err := NewBackend(scope, projectPath)
-	if err != nil {
-		return err
-	}
-	defer b.Close()
-	return b.Put(key, body, tags, time.Now(), "")
 }
 
 // PutWithDedup inserts or updates only if the content hash differs. Delegates through Backend.

--- a/internal/kb/kb_e2e_test.go
+++ b/internal/kb/kb_e2e_test.go
@@ -17,12 +17,12 @@ import (
 func TestE2E_FullLifecycle(t *testing.T) {
 	projectPath := setupTestKB(t)
 
-	// 1. Put entries with explicit types
-	if err := PutWithOptions(config.ScopeLocal, projectPath, "db-decision", "Use PostgreSQL for persistence", []string{"infra"}, "decision"); err != nil {
-		t.Fatalf("PutWithOptions db-decision: %v", err)
+	// 1. Put entries with explicit types (bare tags, no type: prefix)
+	if err := Put(config.ScopeLocal, projectPath, "db-decision", "Use PostgreSQL for persistence", []string{"infra", "decision"}, ""); err != nil {
+		t.Fatalf("Put db-decision: %v", err)
 	}
-	if err := PutWithOptions(config.ScopeLocal, projectPath, "auth-learning", "JWT expiry must be validated server-side", []string{"security"}, "learning"); err != nil {
-		t.Fatalf("PutWithOptions auth-learning: %v", err)
+	if err := Put(config.ScopeLocal, projectPath, "auth-learning", "JWT expiry must be validated server-side", []string{"security", "learning"}, ""); err != nil {
+		t.Fatalf("Put auth-learning: %v", err)
 	}
 	seedEntry(t, projectPath, "readme-note", "Project readme needs updating", []string{"docs"})
 
@@ -216,12 +216,12 @@ func TestE2E_DedupWorkflow(t *testing.T) {
 func TestE2E_SearchRankingWithFilters(t *testing.T) {
 	projectPath := setupTestKB(t)
 
-	// Seed entries: mix of types, tags, and matching terms
-	if err := PutWithOptions(config.ScopeLocal, projectPath, "cache", "Cache invalidation strategy document", []string{"infra"}, "decision"); err != nil {
+	// Seed entries: mix of types, tags, and matching terms (bare tags)
+	if err := Put(config.ScopeLocal, projectPath, "cache", "Cache invalidation strategy document", []string{"infra", "decision"}, ""); err != nil {
 		t.Fatalf("seed cache: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
-	if err := PutWithOptions(config.ScopeLocal, projectPath, "cache-gotcha", "Cache must be invalidated on write", []string{"infra"}, "gotcha"); err != nil {
+	if err := Put(config.ScopeLocal, projectPath, "cache-gotcha", "Cache must be invalidated on write", []string{"infra", "gotcha"}, ""); err != nil {
 		t.Fatalf("seed cache-gotcha: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
@@ -229,7 +229,7 @@ func TestE2E_SearchRankingWithFilters(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	seedEntry(t, projectPath, "db-schema", "Database schema has no cache mention", []string{"db"})
 	time.Sleep(5 * time.Millisecond)
-	if err := PutWithOptions(config.ScopeLocal, projectPath, "session-log", "Session log about cache usage patterns", []string{"infra"}, "learning"); err != nil {
+	if err := Put(config.ScopeLocal, projectPath, "session-log", "Session log about cache usage patterns", []string{"infra", "learning"}, ""); err != nil {
 		t.Fatalf("seed session-log: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)

--- a/internal/kb/kb_e2e_test.go
+++ b/internal/kb/kb_e2e_test.go
@@ -256,7 +256,7 @@ func TestE2E_SearchRankingWithFilters(t *testing.T) {
 		t.Errorf("expected at least 3 infra results for 'cache', got %d", len(results))
 	}
 
-	// --- Filter 2: type=gotcha — only entries with tag type:gotcha
+	// --- Filter 2: type=gotcha — only entries with tag gotcha
 	results, err = SearchWithOptions(config.ScopeLocal, projectPath, "cache", SearchOptions{TypeTag: "gotcha"})
 	if err != nil {
 		t.Fatalf("SearchWithOptions type=gotcha: %v", err)

--- a/internal/kb/kb_test.go
+++ b/internal/kb/kb_test.go
@@ -58,40 +58,36 @@ func TestValidateType(t *testing.T) {
 	}
 }
 
-// --- B-008: PutWithOptions type tag ---
+// --- S-019: ClassifyTag ---
 
-func TestPutWithOptions_TypeTag(t *testing.T) {
-	projectPath := setupTestKB(t)
-
-	err := PutWithOptions(config.ScopeLocal, projectPath, "test-type", "body", []string{"tag1"}, "learning")
-	if err != nil {
-		t.Fatalf("PutWithOptions: %v", err)
+func TestClassifyTag(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want string
+	}{
+		{"learning", "type"},
+		{"gotcha", "type"},
+		{"decision", "type"},
+		{"discovery", "type"},
+		{"session", "type"},
+		{"cvm", "topic"},
+		{"backend", "topic"},
+		{"infra", "topic"},
+		{"auto-captured", "internal"},
+		{"session-buffer", "internal"},
+		{"session-buffer-abc123", "internal"},
+		{"s013", "internal"},
+		{"s017", "internal"},
+		{"type:learning", "internal"},
+		{"type:gotcha", "internal"},
 	}
-
-	entries, err := List(config.ScopeLocal, projectPath, "")
-	if err != nil {
-		t.Fatalf("List: %v", err)
-	}
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(entries))
-	}
-
-	found := false
-	for _, tag := range entries[0].Tags {
-		if tag == "type:learning" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected tag 'type:learning', got tags: %v", entries[0].Tags)
-	}
-}
-
-func TestPutWithOptions_InvalidType(t *testing.T) {
-	projectPath := setupTestKB(t)
-	err := PutWithOptions(config.ScopeLocal, projectPath, "test", "body", nil, "invalid")
-	if err == nil {
-		t.Error("expected error for invalid type")
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			got := ClassifyTag(tt.tag)
+			if got != tt.want {
+				t.Errorf("ClassifyTag(%q) = %q, want %q", tt.tag, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -244,7 +240,7 @@ func TestSearchWithOptions_TagFilter(t *testing.T) {
 func TestSearchWithOptions_TypeFilter(t *testing.T) {
 	projectPath := setupTestKB(t)
 
-	seedEntry(t, projectPath, "typed-entry", "some content", []string{"type:learning", "kb"})
+	seedEntry(t, projectPath, "typed-entry", "some content", []string{"learning", "kb"})
 	seedEntry(t, projectPath, "untyped-entry", "some content too", []string{"kb"})
 
 	results, err := SearchWithOptions(config.ScopeLocal, projectPath, "content", SearchOptions{TypeTag: "learning"})

--- a/internal/kb/sqlite_backend.go
+++ b/internal/kb/sqlite_backend.go
@@ -318,7 +318,7 @@ func (s *SQLiteBackend) Search(query string, opts SearchOptions) ([]SearchResult
 	}
 	if opts.TypeTag != "" {
 		baseQuery += ` AND EXISTS (SELECT 1 FROM json_each(e.tags) WHERE value = ?)`
-		args = append(args, "type:"+opts.TypeTag)
+		args = append(args, opts.TypeTag)
 	}
 	// Spec: S-013 | Req: B-009 — since filter
 	if opts.Since > 0 {
@@ -412,7 +412,7 @@ func (s *SQLiteBackend) searchLike(query string, opts SearchOptions) ([]SearchRe
 	}
 	if opts.TypeTag != "" {
 		likeQuery += ` AND EXISTS (SELECT 1 FROM json_each(e.tags) WHERE value = ?)`
-		args = append(args, "type:"+opts.TypeTag)
+		args = append(args, opts.TypeTag)
 	}
 	if opts.Since > 0 {
 		cutoff := time.Now().Add(-opts.Since).UTC().Format(time.RFC3339Nano)

--- a/internal/mcpkb/server_test.go
+++ b/internal/mcpkb/server_test.go
@@ -112,7 +112,7 @@ func TestKbSearch_Happy(t *testing.T) {
 	_, cleanup := setupTempKB(t)
 	defer cleanup()
 
-	putEntry(t, "arch-decision-api", "Chose REST over gRPC for API design", []string{"decision", "type:decision"})
+	putEntry(t, "arch-decision-api", "Chose REST over gRPC for API design", []string{"decision"})
 	putEntry(t, "api-gateway-notes", "Notes about the API gateway setup", []string{"learning"})
 	putEntry(t, "unrelated-entry", "Nothing about apis here", []string{"gotcha"})
 
@@ -314,7 +314,7 @@ func TestKbGet_Happy(t *testing.T) {
 	_, cleanup := setupTempKB(t)
 	defer cleanup()
 
-	putEntry(t, "my-decision", "Usamos flat files por simplicidad", []string{"decision", "type:decision"})
+	putEntry(t, "my-decision", "Usamos flat files por simplicidad", []string{"decision"})
 
 	result := handleKbGet(rawArgs(t, map[string]interface{}{"key": "my-decision"}))
 	if result.IsError {

--- a/internal/mcpkb/server_test.go
+++ b/internal/mcpkb/server_test.go
@@ -151,8 +151,8 @@ func TestKbSearch_FilterByType(t *testing.T) {
 	_, cleanup := setupTempKB(t)
 	defer cleanup()
 
-	putEntry(t, "bug-fix-2026", "Found a nasty bug", []string{"type:gotcha"})
-	putEntry(t, "arch-v2", "Architecture decision v2", []string{"type:decision"})
+	putEntry(t, "bug-fix-2026", "Found a nasty bug", []string{"gotcha"})
+	putEntry(t, "arch-v2", "Architecture decision v2", []string{"decision"})
 
 	result := handleKbSearch(rawArgs(t, map[string]interface{}{"query": "a", "type": "gotcha"}))
 	if result.IsError {

--- a/profiles/sdd-mem/hooks/context-inject.sh
+++ b/profiles/sdd-mem/hooks/context-inject.sh
@@ -100,11 +100,12 @@ for e in entries[:max_entries * 2]:  # read extra in case some fail
         except Exception:
             pass
 
-    # Extract type from tags
+    # Extract type from tags (bare tags: learning, gotcha, decision, discovery, session)
+    type_tags = {'decision', 'learning', 'gotcha', 'discovery', 'session'}
     entry_type = ''
     for t in tags:
-        if t.startswith('type:'):
-            entry_type = t[5:]
+        if t in type_tags:
+            entry_type = t
             break
     if not entry_type and tags:
         entry_type = tags[0]

--- a/profiles/sdd-mem/hooks/subagent-stop.sh
+++ b/profiles/sdd-mem/hooks/subagent-stop.sh
@@ -80,9 +80,9 @@ while IFS= read -r line; do
 
   # Link entry to current session. Spec: S-017 | Req: B-016
   if [ -n "$session_id" ]; then
-    cvm kb put "$KEY" --body "$BODY" --tag "learning,auto-captured" --session-id "$session_id" 2>/dev/null || true
+    cvm kb put "$KEY" --body "$BODY" --type learning --tag "auto-captured" --session-id "$session_id" 2>/dev/null || true
   else
-    cvm kb put "$KEY" --body "$BODY" --tag "learning,auto-captured" 2>/dev/null || true
+    cvm kb put "$KEY" --body "$BODY" --type learning --tag "auto-captured" 2>/dev/null || true
   fi
   COUNT=$((COUNT + 1))
 done <<< "$LEARNINGS"

--- a/specs/REGISTRY.md
+++ b/specs/REGISTRY.md
@@ -9,3 +9,4 @@
 | S-016 | dashboard | draft | 0.1.0 | manual + browser testing | specs/dashboard.spec.md |
 | S-017 | session-system | approved | 0.4.0 | TDD + manual | specs/session-system.spec.md |
 | S-018 | nested-retro-sessions | draft | 0.1.0 | tests post-impl + manual | specs/nested-retro-sessions.spec.md |
+| S-019 | tag-taxonomy | implemented | 0.3.1 | tests post-impl + manual browser testing | specs/tag-taxonomy.spec.md |

--- a/specs/tag-taxonomy.spec.md
+++ b/specs/tag-taxonomy.spec.md
@@ -1,0 +1,345 @@
+# S-019: KB Tag Taxonomy + Dashboard Tag Visualization
+
+| Field | Value |
+|-------|-------|
+| **ID** | S-019 |
+| **Version** | 0.3.0 |
+| **Status** | implemented |
+| **Validation Strategy** | tests post-impl + manual browser testing |
+| **Related Specs** | S-010 (sdd-mem, tag system), S-016 (dashboard) |
+| **Issues** | #12 (tag taxonomy), #13 (dashboard tag visualization) |
+| **Owner** | chiche |
+
+---
+
+## Objetivo
+
+Clasificar los tags existentes de la KB en dos categorías (tipos y temas) usando una lista fija conocida, mejorar la visualización del dashboard para mostrarlos separados, ocultar tags internos/ruido, y limpiar entries huérfanas sin tipo.
+
+---
+
+## Contexto
+
+Hoy los tags se guardan como strings planos sin distinción. Los tags que representan "qué es" (`learning`, `gotcha`, `decision`) se mezclan con tags que representan "de qué trata" (`cvm`, `backend`, `infra`) y con tags internos/ruido (`auto-captured`, `s013`, `session-buffer`).
+
+El mecanismo `--type` con prefijo `type:` existe en el código pero nunca se usó en producción. Todos los hooks, retros, y skills escriben tags bare con `--tag`. Esta spec no cambia eso — clasifica en base a una lista conocida.
+
+---
+
+## Alcance
+
+### Incluido
+
+| ID | Item | Descripción |
+|----|------|-------------|
+| B-001 | Lista de type tags conocidos | Variable exportada con los tags que representan tipo |
+| B-002 | `IsInternalTag()` | Función que identifica tags de ruido a ocultar del dashboard |
+| B-003 | `ClassifyTag()` | Función que clasifica un tag en `type`, `topic`, o `internal` |
+| B-004 | Stats API restructurada | `/api/stats` retorna `by_type` y `by_topic` en vez de `by_tag` flat |
+| B-005 | Frontend: tags agrupados | Stats view muestra tipos y temas en secciones separadas |
+| B-006 | Frontend: click-to-filter | Click en un tag en Stats navega a Browser tab con ese tag pre-filtrado |
+| B-007 | Comando `cvm kb migrate-tags` | Elimina entries sin tag de tipo + limpia tags internos |
+| B-008 | Cleanup dead code | Remover código muerto relacionado al mecanismo `type:` prefix no usado |
+
+### Excluido
+
+- Cambios al formato de almacenamiento de tags (siguen siendo `[]string` bare)
+- Nuevos tipos (se mantienen los 5 existentes)
+- Validación forzada al escribir (no se bloquea un `kb put` sin tipo)
+- Cambios a `cvm kb search` (ya funciona con `--tag`)
+
+---
+
+## Contratos
+
+### C-001: Clasificación de tags
+
+```go
+// Spec: S-019 | Req: B-001
+var TypeTags = []string{"decision", "learning", "gotcha", "discovery", "session"}
+
+// Spec: S-019 | Req: B-002
+var InternalTags = []string{"auto-captured", "session-buffer"}
+
+// Spec: S-019 | Req: B-003
+func ClassifyTag(tag string) string // returns "type", "topic", or "internal"
+```
+
+- **C-001a**: `ClassifyTag("learning")` MUST retornar `"type"`.
+- **C-001b**: `ClassifyTag("auto-captured")` MUST retornar `"internal"`.
+- **C-001c**: `ClassifyTag("session-buffer")` MUST retornar `"internal"`.
+- **C-001d**: `ClassifyTag("cvm")` MUST retornar `"topic"`.
+- **C-001e**: `ClassifyTag("s013")` MUST retornar `"internal"` (tags que matchean `^s\d{3}$`).
+- **C-001f**: Tags con prefijo `type:` MUST ser clasificados como `"internal"` (son residuo del mecanismo no usado).
+- **C-001g**: Tags con prefijo `session-buffer` MUST ser clasificados como `"internal"`.
+
+### C-002: Stats API restructurada
+
+```
+GET /api/stats
+```
+
+Respuesta (cambio respecto a S-016):
+
+```json
+{
+  "global": {
+    "total": 42,
+    "enabled": 40,
+    "stale": 5,
+    "total_tokens": 12400,
+    "by_type": {
+      "learning": 15,
+      "gotcha": 8,
+      "decision": 12
+    },
+    "by_topic": {
+      "cvm": 5,
+      "backend": 3,
+      "infra": 2
+    }
+  },
+  "local": { ... },
+  "active_sessions": 1
+}
+```
+
+- **C-002a**: `by_type` MUST contener solo tags donde `ClassifyTag() == "type"`.
+- **C-002b**: `by_topic` MUST contener solo tags donde `ClassifyTag() == "topic"`.
+- **C-002c**: Tags internos (`ClassifyTag() == "internal"`) MUST ser excluidos.
+- **C-002d**: El field `by_tag` MUST ser removido (reemplazado por `by_type` y `by_topic`).
+
+### C-003: Frontend Stats View
+
+- **C-003a**: La sección de tags MUST mostrar dos grupos: "Types" y "Topics".
+- **C-003b**: Cada grupo MUST estar ordenado por count descendente.
+- **C-003c**: Si un grupo no tiene entries, MUST no mostrarse.
+- **C-003d**: Los badges de tipo MUST usar los colores existentes de `TAG_COLORS` (`badge-learning`, `badge-gotcha`, `badge-decision`).
+- **C-003e**: Los badges de topic MUST usar `badge-default`.
+
+### C-004: Click-to-filter
+
+- **C-004a**: Click en un tag (tipo o topic) en Stats MUST navegar a `#browser` con el tag como filtro.
+- **C-004b**: El Browser tab MUST leer el tag de la URL al cargar y pre-filtrar la búsqueda.
+
+### C-005: Migration command
+
+```
+cvm kb migrate-tags [--dry-run] [--local]
+```
+
+- **C-005a**: MUST eliminar toda entry que no tenga al menos un tag de tipo (donde `ClassifyTag(tag) == "type"`).
+- **C-005b**: Entries con key que empieza por `session-buffer-` MUST ser eliminadas (son residuo del sistema viejo S-011/S-015, superseded por S-017).
+- **C-005c**: `--dry-run` MUST imprimir los cambios propuestos sin aplicarlos.
+- **C-005d**: `--local` MUST operar sobre la KB local en vez de la global.
+- **C-005e**: MUST imprimir un resumen: `"Deleted N untyped entries, removed M session-buffer entries"`.
+- **C-005f**: Si no hay cambios, MUST imprimir `"No changes needed"`.
+
+### C-006: Cleanup dead code
+
+**Go — `internal/kb/kb.go`:**
+- **C-006a**: `PutWithOptions()` (line 337) MUST ser removida. Es dead code — nadie la llama en producción. El CLI reimplementa la misma lógica inline en `cmd/kb.go`.
+- **C-006b**: Los tests que usan `PutWithOptions` (`kb_test.go:63 TestPutWithOptions_TypeTag`, `kb_test.go:90 TestPutWithOptions_InvalidType`, y los usos en `kb_e2e_test.go`) MUST ser actualizados para usar `Put()` directo o el path de CLI.
+
+**Go — `cmd/kb.go`:**
+- **C-006c**: `--type` en `cvm kb put` (line 50) MUST almacenar el tag bare. Cambiar `tags = append(tags, "type:"+typeTag)` a `tags = append(tags, typeTag)`.
+
+**Go — `internal/kb/sqlite_backend.go`:**
+- **C-006d**: `SearchOptions.TypeTag` filter (lines 319-321, 413-415) MUST buscar el tag bare. Cambiar `"type:"+opts.TypeTag` a `opts.TypeTag`.
+
+**Go — `internal/kb/flat.go`:**
+- **C-006e**: `TypeTag` filter (lines 155-160) MUST buscar el tag bare. Cambiar `"type:"+opts.TypeTag` a `opts.TypeTag`.
+
+**JS — `internal/dashboard/web/static/app.js`:**
+- **C-006f**: `tag.replace(/^type:/, '')` en `badgeClass()` (line 74) MUST ser removido. Nunca hay tags con prefijo `type:` en producción — es un no-op.
+- **C-006g**: `TAG_COLORS` entries `summary` y `spec-gap` (lines 69-70) MUST ser removidas. Esos tipos no existen.
+- **C-006h**: Los CSS classes `badge-summary` y `badge-spec-gap` en `style.css` MUST ser removidos.
+
+**Go — `internal/dashboard/api.go`:**
+- **C-006i**: La exclusión de `session-buffer-` en el listado de sesiones (line 827) MUST ser removida. Las session-buffer entries son residuo del sistema viejo (S-011/S-015) y la migration las elimina. Post-migration no hay entries con ese patrón.
+
+---
+
+## Behaviors
+
+### B-001: Stats API con tags mixtos
+
+**Given** la KB global tiene:
+- Entry A con tags `["learning", "cvm"]`
+- Entry B con tags `["gotcha", "infra"]`
+- Entry C con tags `["learning", "auto-captured", "s017"]`
+**When** el browser hace `GET /api/stats`
+**Then**:
+- `global.by_type` = `{"learning": 2, "gotcha": 1}`
+- `global.by_topic` = `{"cvm": 1, "infra": 1}`
+- `auto-captured` y `s017` NO aparecen
+
+### B-002: Frontend muestra tags agrupados
+
+**Given** el dashboard muestra `by_type: {learning: 5, gotcha: 3}` y `by_topic: {backend: 2, cvm: 4}`
+**When** el usuario navega al tab Stats
+**Then**:
+- Ve una sección "Types" con badges `learning (5)`, `gotcha (3)`
+- Ve una sección "Topics" con badges `cvm (4)`, `backend (2)`
+
+### B-003: Click tag filtra Browser
+
+**Given** Stats muestra `learning (5)` en la sección Types
+**When** el usuario clickea el badge `learning`
+**Then**:
+- El tab activo cambia a Browser
+- El filtro de tag se pre-llena con `learning`
+- Los resultados muestran solo entries con tag `learning`
+
+### B-004: Migration limpia entries sin tipo
+
+**Given** la KB tiene:
+- Entry X con tags `["learning", "cvm"]` (tiene tipo)
+- Entry Y con tags `["infra", "auto-captured"]` (sin tipo)
+- Entry Z con key `"session-buffer-abc123"` y tags `["session-buffer"]`
+- Entry W con tags `["decision", "backend"]` (tiene tipo)
+**When** el usuario ejecuta `cvm kb migrate-tags`
+**Then**:
+- Entry X: sin cambios
+- Entry Y: eliminada (no tiene tag de tipo)
+- Entry Z: eliminada (session-buffer residuo)
+- Entry W: sin cambios
+- Output: `"Deleted 1 untyped entries, removed 1 session-buffer entries"`
+
+### B-005: Dry run
+
+**Given** la KB tiene entries para limpiar
+**When** el usuario ejecuta `cvm kb migrate-tags --dry-run`
+**Then**:
+- Imprime las entries que serían eliminadas
+- No elimina nada
+- Output incluye `"[dry-run]"` prefix
+
+### B-006: --type flag corregido
+
+**Given** el usuario ejecuta `cvm kb put "my-key" --body "content" --type learning --tag "cvm"`
+**When** la entry se guarda
+**Then**:
+- Tags resultantes: `["learning", "cvm"]`
+- NO `["type:learning", "cvm"]`
+
+---
+
+## Edge Cases
+
+| ID | Scenario | Expected Behavior |
+|----|----------|------------------|
+| E-001 | Entry tiene tag `"type:learning"` (residuo viejo) | `ClassifyTag` lo clasifica como `"internal"`. Migration la elimina si no tiene otro tag de tipo bare. |
+| E-002 | `cvm kb migrate-tags` en KB vacía | MUST imprimir `"No changes needed"` y exit 0. |
+| E-003 | Stats con 0 entries en un scope | `by_type` y `by_topic` MUST ser `{}` (empty map), no `null`. |
+| E-004 | Browser tab cargado con tag filter que no existe | MUST mostrar 0 resultados sin error. |
+| E-005 | Entry tiene tag `"session"` (es un ValidType) | `ClassifyTag("session")` retorna `"type"`. La entry se mantiene. |
+
+---
+
+## Invariantes
+
+| ID | Invariante |
+|----|------------|
+| I-001 | Tags internos NEVER aparecen en `by_type` o `by_topic` del stats response. |
+| I-002 | `cvm kb search --tag learning` MUST seguir funcionando idéntico (no breaking change). |
+| I-003 | El dashboard MUST seguir siendo read-only. La migration es un comando CLI separado. |
+| I-004 | Después de migration, toda entry (excepto residuos aún no limpiados en local) MUST tener al menos un tag de tipo. |
+
+---
+
+## Errores
+
+| Situación | Comportamiento |
+|-----------|----------------|
+| `--type` con tipo inválido (e.g., `--type foo`) | CLI error: `"invalid type \"foo\": must be one of decision, learning, gotcha, discovery, session"` |
+| `migrate-tags` falla al eliminar una entry | Loguear warning y continuar con las demás. Reportar failures en el resumen. |
+
+---
+
+## Restricciones No Funcionales
+
+| ID | Restricción |
+|----|-------------|
+| NF-001 | `GET /api/stats` MUST seguir respondiendo en < 300ms con 2000 entries. |
+| NF-002 | `migrate-tags` MUST completar en < 5 segundos para 1000 entries. |
+
+---
+
+## Plan de Implementación
+
+### Wave 1 — Clasificación de tags + cleanup Go (Go)
+
+**Archivos:** `internal/kb/kb.go`, `internal/kb/sqlite_backend.go`, `internal/kb/flat.go`, `cmd/kb.go`, `internal/kb/kb_test.go`, `internal/kb/kb_e2e_test.go`
+
+1. Agregar `TypeTags`, `InternalTags` variables exportadas
+2. Agregar `ClassifyTag()` function
+3. Remover `PutWithOptions()` (dead code) — C-006a
+4. Actualizar tests que usaban `PutWithOptions` — C-006b
+5. Fix `--type` en `cvm kb put`: almacenar bare tag — C-006c
+6. Fix `TypeTag` filter en sqlite_backend.go: buscar bare — C-006d
+7. Fix `TypeTag` filter en flat.go: buscar bare — C-006e
+8. Tests unitarios para `ClassifyTag` y para el flag `--type` corregido
+
+**Gate:** `go test ./...` pasa. `cvm kb put --type learning` guarda `"learning"` (no `"type:learning"`).
+
+### Wave 3 — Migration command (Go)
+
+**Archivos:** `cmd/kb.go`
+
+1. Implementar subcommand `cvm kb migrate-tags`
+2. Flags: `--dry-run`, `--local`
+3. Lógica: eliminar entries sin tag de tipo + session-buffer residuos
+4. Tests
+
+**Gate:** `cvm kb migrate-tags --dry-run` lista entries a eliminar.
+
+### Wave 4 — Dashboard API (Go)
+
+**Archivos:** `internal/dashboard/api.go`
+
+1. Cambiar `scopeStatsJSON`: reemplazar `ByTag` con `ByType` y `ByTopic`
+2. En `buildScopeStats()`: usar `ClassifyTag()` para clasificar
+3. Remover exclusión de `session-buffer-` en listado de sesiones (line 827) — C-006i
+4. Tests
+
+**Gate:** `curl /api/stats` retorna respuesta restructurada.
+
+### Wave 5 — Frontend (JS/CSS)
+
+**Archivos:** `internal/dashboard/web/static/app.js`, `internal/dashboard/web/static/style.css`
+
+1. Actualizar Stats rendering para dos secciones (Types, Topics)
+2. Implementar click-to-filter: click badge → navegar a `#browser` con tag filter
+3. Actualizar Browser tab para leer tag de URL al cargar
+4. Remover `tag.replace(/^type:/, '')` de `badgeClass()` — C-006f
+5. Remover `summary` y `spec-gap` de `TAG_COLORS` — C-006g
+6. Remover `badge-summary` y `badge-spec-gap` de CSS — C-006h
+
+**Gate:** Dashboard muestra tags agrupados, click filtra correctamente.
+
+---
+
+## Specs Relacionadas
+
+- **S-010** (sdd-mem): Define `ValidTypes` — esta spec reutiliza la misma lista como `TypeTags`
+- **S-016** (dashboard): Define `/api/stats` — esta spec reemplaza `by_tag` con `by_type` + `by_topic`
+
+---
+
+## Dependencias
+
+- `internal/kb` — Entry struct, Backend interface (no schema change)
+- `internal/dashboard` — API handlers, frontend assets
+- Sin nuevas dependencias externas
+
+---
+
+## Changelog
+
+| Version | Fecha | Cambio |
+|---------|-------|--------|
+| 0.1.0 | 2026-04-14 | Draft inicial |
+| 0.2.0 | 2026-04-14 | Removida dimensión area. Sin tipos nuevos. Agregado cleanup. |
+| 0.3.0 | 2026-04-14 | Reescrita desde cero basada en auditoría del código real. Sin prefijo `type:`. Clasificación por lista conocida. |
+| 0.3.1 | 2026-04-14 | Inventario completo de dead code con file:line exacto (C-006a a C-006i). |

--- a/specs/tag-taxonomy.spec.md
+++ b/specs/tag-taxonomy.spec.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |-------|-------|
 | **ID** | S-019 |
-| **Version** | 0.3.0 |
+| **Version** | 0.3.1 |
 | **Status** | implemented |
 | **Validation Strategy** | tests post-impl + manual browser testing |
 | **Related Specs** | S-010 (sdd-mem, tag system), S-016 (dashboard) |


### PR DESCRIPTION
## Summary

- Standardize KB tags: `ClassifyTag()` separates type tags (`learning`, `gotcha`, `decision`, `discovery`, `session`) from topic tags (`cvm`, `backend`, `infra`) and internal tags (`auto-captured`, `session-buffer`, `s013`)
- Dashboard stats API returns `by_type` + `by_topic` instead of flat `by_tag`, internal tags excluded
- Frontend shows grouped sections (Types / Topics) with click-to-filter to Browser tab
- New `cvm kb migrate-tags` command: deletes entries without a type tag + session-buffer residues
- Dead code cleanup: `PutWithOptions()`, `type:` prefix mechanism, unused CSS/JS badge classes

## Spec

`specs/tag-taxonomy.spec.md` (S-019 v0.3.1)

Closes #12, closes #13

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] `go build ./...` passes
- [ ] Manual: `cvm dashboard` → Stats tab shows Types and Topics separately
- [ ] Manual: Click a tag badge in Stats → navigates to Knowledge tab with filter
- [ ] Manual: `cvm kb migrate-tags --dry-run` lists entries to delete
- [ ] Manual: `cvm kb put test --body "x" --type learning` stores bare `learning` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)