### PR TITLE
feat(#29): Agregar skill /che-loop para automatizar validate-iterate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin/
 dist/
 .claude/
+.worktrees/
+EXEC_NOTES.md

--- a/EXEC_NOTES.md
+++ b/EXEC_NOTES.md
@@ -1,0 +1,32 @@
+# EXEC_NOTES — issue #29 (`/che-loop`)
+
+## Lo que se hizo
+
+- Nuevo skill `profiles/lite/skills/che-loop/SKILL.md` (264 lineas).
+- Nueva fila `/che-loop` en `profiles/lite/CLAUDE.md`, ubicada entre `/che-iterate` y `/che-close` (orden logico del flujo: validate → iterate → loop sobre ambos → close).
+- Texto del bullet "los 6 skills che" actualizado: ahora distingue los 6 que tocan state machine vs `/che-loop` que es orquestador puro.
+- `profiles/lite/install.sh` NO se modifico — ya itera `*/SKILL.md` automaticamente y va a sincronizar `che-loop` al redeploy.
+
+## Decisiones de diseno destacadas
+
+1. **Composicion via Skill tool, no reimplementacion.** El skill invoca `/che-validate` y `/che-iterate` directamente. Cualquier cambio futuro en el filtrado de comments, fetch o transitions vive en los hermanos, no aca.
+2. **Lectura del verdict desde labels (`validated:*` / `plan-validated:*`), no del stdout del Skill tool.** Los labels son el contrato persistido en GitHub que `/che-validate` aplica al final; leerlos es deterministico y resiliente al formato del reporte.
+3. **No tocar `che:*` directamente.** El loop no aplica locks ni transitions propias — `che:looping` no existe en la state machine de che-cli (`labels.go`). Documentado en MUST NOT DO.
+4. **Idempotencia por IDs crudos de comments.** Comparar IDs sin filtrar puede dar false positives (ej: alguien dejo un `+1` nuevo) pero evita acoplar el loop al filtrado interno de `/che-iterate`. Conservador en favor de simplicidad.
+5. **`--max=3` default.** Cubre "primera review pide cambios → fix → segunda review aprueba" con buffer extra. Mas que eso suele indicar idempotencia o needs-human. Override explicito disponible (rango `1 ≤ N ≤ 20`).
+6. **Salida inmediata en `needs-human`.** No iteramos; `/che-iterate` no resuelve trade-offs que requieren decision humana.
+7. **Precheck de PR (branch == headRefName + working tree limpio) ANTES del primer `/che-validate`.** `/che-iterate` ya aborta si esto no se cumple, pero hacerlo arriba evita gastar una validate. Para issues no aplica.
+
+## Dual location (`~/.claude/skills/`)
+
+Segun la memoria `lite_profile_dual_location.md`, los skills viven tanto en `~/.claude/skills/` (runtime) como en `profiles/lite/skills/` (fuente del repo). En este worktree solo se modifico la fuente del repo. El sync a `~/.claude/skills/che-loop/SKILL.md` lo hace `cvm install` / `bash profiles/lite/install.sh` post-merge.
+
+## Pendiente
+
+Nada bloqueante. La verificacion end-to-end del loop (validate → iterate → validate sobre un PR real con cambios pedidos) requiere correrlo despues del merge, idealmente sobre un PR de prueba con comments accionables.
+
+## Validacion ejecutada en este run
+
+- No hay markdown linter ni skill validator en el repo (`Makefile` solo corre `go test`).
+- Frontmatter consistente con los hermanos: primera linea es la descripcion en una sola oracion (ningun skill del profile lite usa YAML frontmatter).
+- `install.sh` no requiere cambios — usa glob `*/SKILL.md` y picks up `che-loop` automaticamente.

--- a/profiles/lite/CLAUDE.md
+++ b/profiles/lite/CLAUDE.md
@@ -12,9 +12,10 @@
 | `/che-execute` | Implementar issue/tarea en worktree aislado + abrir PR draft; aplica `che:executing→che:executed` |
 | `/che-validate` | Revisar PR/issue (subagentes paralelos); aplica `che:validating→che:validated` + verdict |
 | `/che-iterate` | Aplicar comments de PR/issue (subagent Opus); aplica transitions `che:executing\|planning` |
+| `/che-loop` | Automatiza `che-validate→che-iterate→...` hasta verdict=approve, 0 comments accionables, `--max N` (default 3), o idempotencia. No toca labels `che:*` directamente — compone los skills hermanos |
 | `/che-close` | Cerrar PR (ready→CI→merge→close issues linkeados); aplica `che:closing→che:closed` |
 
-Los 6 skills "che" (`/che-idea`, `/che-explore`, `/che-execute`, `/che-validate`, `/che-iterate`, `/che-close`) replican el workflow de [che-cli](https://github.com/chichex/che-cli) en modo lenient — aplican las mismas transitions de la state machine `che:*` (ver `che-cli/internal/labels/labels.go`) pero no abortan si current state no calza con `from` (warnean y aplican igual).
+Los 6 skills "che" que tocan la state machine (`/che-idea`, `/che-explore`, `/che-execute`, `/che-validate`, `/che-iterate`, `/che-close`) replican el workflow de [che-cli](https://github.com/chichex/che-cli) en modo lenient — aplican las mismas transitions de la state machine `che:*` (ver `che-cli/internal/labels/labels.go`) pero no abortan si current state no calza con `from` (warnean y aplican igual). `/che-loop` es un orquestador puro que compone `/che-validate` y `/che-iterate` via Skill tool y NO aplica labels `che:*` por su cuenta.
 
 Usa `/go` directamente cuando sabes que agente necesitas (default Opus; agrega `--codex` o `--gemini` para CLIs externos).
 

--- a/profiles/lite/CLAUDE.md
+++ b/profiles/lite/CLAUDE.md
@@ -15,7 +15,7 @@
 | `/che-loop` | Automatiza `che-validate→che-iterate→...` hasta verdict=approve, 0 comments accionables, `--max N` (default 3), o idempotencia. No toca labels `che:*` directamente — compone los skills hermanos |
 | `/che-close` | Cerrar PR (ready→CI→merge→close issues linkeados); aplica `che:closing→che:closed` |
 
-Los 6 skills "che" que tocan la state machine (`/che-idea`, `/che-explore`, `/che-execute`, `/che-validate`, `/che-iterate`, `/che-close`) replican el workflow de [che-cli](https://github.com/chichex/che-cli) en modo lenient — aplican las mismas transitions de la state machine `che:*` (ver `che-cli/internal/labels/labels.go`) pero no abortan si current state no calza con `from` (warnean y aplican igual). `/che-loop` es un orquestador puro que compone `/che-validate` y `/che-iterate` via Skill tool y NO aplica labels `che:*` por su cuenta.
+Los skills "che" que tocan la state machine (`/che-idea`, `/che-explore`, `/che-execute`, `/che-validate`, `/che-iterate`, `/che-close`) replican el workflow de [che-cli](https://github.com/chichex/che-cli) en modo lenient — aplican las mismas transitions de la state machine `che:*` (ver `che-cli/internal/labels/labels.go`) pero no abortan si current state no calza con `from` (warnean y aplican igual). `/che-loop` es un orquestador puro que compone `/che-validate` y `/che-iterate` via Skill tool y NO aplica labels `che:*` por su cuenta.
 
 Usa `/go` directamente cuando sabes que agente necesitas (default Opus; agrega `--codex` o `--gemini` para CLIs externos).
 

--- a/profiles/lite/skills/che-iterate/SKILL.md
+++ b/profiles/lite/skills/che-iterate/SKILL.md
@@ -4,12 +4,14 @@ Aplica comments/reviews de un PR o issue lanzando un agente Opus con el contexto
 
 Outputs observables que otros skills (especialmente `/che-loop`) pueden parsear con garantia de estabilidad. Cambiar estos strings es breaking change — sincronizar con consumers.
 
-- **Resumen final** (Paso 7): el reporte termina con un bloque que incluye literalmente la linea `Procesados por el agente: <Z>` donde `<Z>` es un entero (`0`, `1`, `2`, ...). Este es el campo parseable canonico para "cuantos comments aplico el iterate".
-  - `Z == 0` → no hubo cambios accionables / nada se commiteo (rollback aplicado).
-  - `Z >= 1` → hubo cambios; `git commit + push` (PR) o `gh issue edit` (issue) ya corrieron antes de retornar.
+- **Resumen final** (Paso 7): el reporte termina con un bloque markdown formateado como bullet-list, donde cada linea arranca con el prefijo literal `- ` (guion + espacio). Las lineas parseables del contrato son **exactamente**:
+  - `- Procesados por el agente: <Z>` donde `<Z>` es un entero (`0`, `1`, `2`, ...). Este es el campo parseable canonico para "cuantos comments aplico el iterate". El prefijo `- ` es parte del contrato — el consumer (`/che-loop` Paso 4.9) usa el regex `^- Procesados por el agente: [0-9]+$` y depende del bullet.
+    - `Z == 0` → no hubo cambios accionables / nada se commiteo (rollback aplicado).
+    - `Z >= 1` → hubo cambios; `git commit + push` (PR) o `gh issue edit` (issue) ya corrieron antes de retornar.
+  - `- Persistencia: <detalle>`. Si la persistencia fallo, el detalle arranca con `failed:` literal — la linea completa tiene el shape `- Persistencia: failed: <error>`. El consumer usa `^- Persistencia: failed:` para detectar la falla. El prefijo `- ` tambien es parte del contrato.
 - **Persistencia previa al return**: para `KIND=pr` con `Z >= 1`, el commit ya esta en `origin/<headRefName>` cuando el skill retorna. Para `KIND=issue` con `Z >= 1`, el body ya esta editado en GitHub. Es seguro lanzar `/che-validate` inmediatamente despues — vera el estado nuevo.
 - **Labels post-return**: aplica `che:executed` (PR) / `che:plan` (issue) en success, o vuelve a `che:validated` (rollback) si el agente reporto 0 aplicados o si la persistencia fallo. Leer label es deterministico; el resumen markdown es para el humano.
-- **Falla de persistencia**: si `git commit` / `git push` (PR) o `gh issue edit` (issue) falla, el resumen incluye explicitamente la palabra `failed` en la linea `Persistencia: ...` y el lock se rolleo a `che:validated`. El consumer (ej `/che-loop`) debe tratar esto como exit reason terminal — el humano resuelve a mano.
+- **Falla de persistencia**: si `git commit` / `git push` (PR) o `gh issue edit` (issue) falla, el resumen incluye explicitamente la palabra `failed` en la linea `- Persistencia: ...` y el lock se rolleo a `che:validated`. El consumer (ej `/che-loop`) debe tratar esto como exit reason terminal — el humano resuelve a mano.
 
 ## Tagging (state machine de che-cli)
 
@@ -29,6 +31,14 @@ Aplica las transitions de `che-cli/internal/labels/labels.go`:
 ### Paso 1: Parsear `$ARGUMENTS` y resolver target
 
 **Precheck de auth** (antes de cualquier `gh` que haga red): correr `gh auth status` una sola vez. Si falla, abortar inmediatamente con: "gh no esta autenticado o no hay red — corre `gh auth login` y reintenta.". Esto evita confundir un "not found" real con un fallo de auth/red en los pasos siguientes.
+
+**Crear directorio temp namespaced por PID** (antes de escribir cualquier scratch file). Asi dos runs concurrentes de `/che-iterate` (o de `/che-loop` componiendo iterate) no se pisan contexto/diff/body:
+
+```bash
+ITER_TMP=$(mktemp -d -t cvm-iterate-XXXXXX)
+```
+
+Todos los scratch paths del skill (`$ITER_TMP/context.md`, `$ITER_TMP/diff.txt`, `$ITER_TMP/new-body.md`) viven dentro de `$ITER_TMP`. NO usar paths globales `/tmp/cvm-iterate-*` — corrompen runs paralelos.
 
 Detectar el formato:
 
@@ -106,7 +116,7 @@ Mantener todo lo demas, incluyendo comments cortos con contenido accionable (p.e
 
 ### Paso 4: Armar archivo de contexto
 
-Escribir `/tmp/cvm-iterate-context.md` via Write tool. NUNCA interpolar bodies de comments en shell. Estructura:
+Escribir `$ITER_TMP/context.md` via Write tool. NUNCA interpolar bodies de comments en shell. Estructura:
 
 ```markdown
 # Iteracion sobre <PR|Issue> #<N>
@@ -128,7 +138,7 @@ Escribir `/tmp/cvm-iterate-context.md` via Write tool. NUNCA interpolar bodies d
 <si el diff <= 2000 lineas: pegarlo inline dentro de un bloque `diff`>
 <si > 2000 lineas: NO pegarlo — en su lugar escribir la nota de abajo>
 
-> Diff con <N> lineas — truncado. Disponible completo en `/tmp/cvm-iterate-diff.txt`. Leer bajo demanda.
+> Diff con <N> lineas — truncado. Disponible completo en `$ITER_TMP/diff.txt`. Leer bajo demanda.
 
 ## Comments (<total> tras filtrado; <descartados> descartados)
 
@@ -158,12 +168,12 @@ Numerar los comments en orden cronologico (por `created_at`). Si no quedo ningun
 
 Para el diff del PR, **siempre** dumpear a archivo (nunca interpolar via shell) y luego decidir si inlinearlo:
 ```bash
-gh pr diff "$N" > /tmp/cvm-iterate-diff.txt 2>/dev/null
-wc -l /tmp/cvm-iterate-diff.txt
+gh pr diff "$N" > "$ITER_TMP/diff.txt" 2>/dev/null
+wc -l "$ITER_TMP/diff.txt"
 ```
 
 - Si `wc -l` ≤ **2000**: leer con `Read` y pegar dentro del bloque `diff` en el contexto.
-- Si > **2000**: NO inlinearlo. Dejar la nota "truncado — disponible en `/tmp/cvm-iterate-diff.txt`" y el agente lo lee bajo demanda con `Read` (offset/limit) cuando necesita inspeccionar un cambio puntual. Esto evita saturar el context window del agente Opus en PRs grandes.
+- Si > **2000**: NO inlinearlo. Dejar la nota "truncado — disponible en `$ITER_TMP/diff.txt`" y el agente lo lee bajo demanda con `Read` (offset/limit) cuando necesita inspeccionar un cambio puntual. Esto evita saturar el context window del agente Opus en PRs grandes.
 
 ### Paso 4.5: Pre-transition (lock)
 
@@ -232,10 +242,10 @@ Agent(
 
 El prompt del agente difiere segun `KIND`:
 
-**Si `KIND=pr`** (sustituyendo `<N>`):
+**Si `KIND=pr`** (sustituyendo `<N>` y `<ITER_TMP>` por los valores reales antes de despachar):
 
 ```
-Tenes acceso al filesystem del worktree actual. El contexto completo esta en /tmp/cvm-iterate-context.md — leelo primero.
+Tenes acceso al filesystem del worktree actual. El contexto completo esta en <ITER_TMP>/context.md — leelo primero.
 
 Tarea: evaluar los comments/reviews del PR #<N> y aplicar al codigo los cambios que sean accionables.
 
@@ -260,10 +270,10 @@ Reporte estructurado con:
 Termina tu respuesta con una seccion `## Key Learnings:` listando descubrimientos no-obvios sobre el codebase o el feedback que puedan ser utiles en futuras iteraciones.
 ```
 
-**Si `KIND=issue`** (plan iteration — sustituyendo `<N>`):
+**Si `KIND=issue`** (plan iteration — sustituyendo `<N>` y `<ITER_TMP>` por los valores reales antes de despachar):
 
 ```
-Tenes acceso al filesystem del worktree actual. El contexto completo esta en /tmp/cvm-iterate-context.md — leelo primero.
+Tenes acceso al filesystem del worktree actual. El contexto completo esta en <ITER_TMP>/context.md — leelo primero.
 
 Tarea: el issue #<N> es un plan que recibio comments/reviews pidiendo cambios. Re-escribi el body del issue incorporando el feedback accionable. NO toques archivos del repo — el resultado es un nuevo body para el issue.
 
@@ -274,11 +284,11 @@ Criterios:
 4. Comments ambiguos: anotarlos en "Notas" como "pendiente de aclaracion" — NO inventar interpretacion.
 
 Output del subagent (ESTRICTO):
-1. Escribir el nuevo body completo (markdown) a `/tmp/cvm-iterate-new-body.md` con Write tool.
+1. Escribir el nuevo body completo (markdown) a `<ITER_TMP>/new-body.md` con Write tool.
 2. En tu respuesta, devolver un reporte con:
    - ## Aplicados — comments incorporados al body y donde
    - ## Ignorados — comments no aplicados y la razon
-   - ## Body actualizado — confirmar que escribiste a `/tmp/cvm-iterate-new-body.md`
+   - ## Body actualizado — confirmar que escribiste a `<ITER_TMP>/new-body.md`
 
 Restricciones:
 - NO modifiques archivos del repo.
@@ -307,12 +317,12 @@ Capturar exit code de cada paso:
 
 Si el agente reporto 0 aplicados → saltar este paso (no hay nada que commitear); ir directo a rollback en Paso 6.b.
 
-**Si `KIND=issue`** y el agente escribio `/tmp/cvm-iterate-new-body.md`:
+**Si `KIND=issue`** y el agente escribio `$ITER_TMP/new-body.md`:
 
 ```bash
 # Verificar que el archivo existe y no esta vacio
-[[ -s /tmp/cvm-iterate-new-body.md ]] || { echo "Subagent no genero nuevo body"; exit 1; }
-gh issue edit "$N" --repo "$OWNER/$REPO" --body-file /tmp/cvm-iterate-new-body.md
+[[ -s "$ITER_TMP/new-body.md" ]] || { echo "Subagent no genero nuevo body"; exit 1; }
+gh issue edit "$N" --repo "$OWNER/$REPO" --body-file "$ITER_TMP/new-body.md"
 ```
 
 Si `gh issue edit` falla → rollback del lock + warnear.
@@ -359,13 +369,14 @@ Luego, el **skill** (no el subagent) invoca `/r` usando el Skill tool para persi
 - Detectar PR vs issue con fallback `gh pr view` → `gh issue view`.
 - Usar `gh api --paginate` para los tres endpoints cuando `KIND=pr`, solo `issues/<N>/comments` cuando `KIND=issue`.
 - Filtrar comments del autor (excepto si empiezan con `## Review:` — reviews machine-generated de `/che-validate`), reacciones puras (regex case-insensitive, **tras strip de `\s+` incluyendo newlines**), y reviews APPROVED vacios antes de pasar al agente.
-- Escribir el contexto a `/tmp/cvm-iterate-context.md` con Write tool; el prompt del agente referencia el path.
-- Dumpear el diff a `/tmp/cvm-iterate-diff.txt` **siempre**; inlinearlo en el contexto solo si tiene ≤ 2000 lineas. Si es mas grande, dejar solo el puntero al archivo.
+- Crear `ITER_TMP=$(mktemp -d -t cvm-iterate-XXXXXX)` al inicio del Paso 1 y usar `$ITER_TMP/context.md`, `$ITER_TMP/diff.txt`, `$ITER_TMP/new-body.md` para todos los scratch files. NO usar paths globales `/tmp/cvm-iterate-*` (corrompen runs concurrentes).
+- Escribir el contexto a `$ITER_TMP/context.md` con Write tool; el prompt del agente referencia el path (sustituir `<ITER_TMP>` por el valor real antes de despachar).
+- Dumpear el diff a `$ITER_TMP/diff.txt` **siempre**; inlinearlo en el contexto solo si tiene ≤ 2000 lineas. Si es mas grande, dejar solo el puntero al archivo.
 - Resolver `CURRENT_STATE` via stateref: PR labels primero, fallback a labels del issue linkeado (`closingIssuesReferences`).
 - Aplicar pre-transition (lock) ANTES del subagent. Lenient: si state actual no es `che:validated`, warn + limpiar `che:*` previos + aplicar el lock.
 - Para `KIND=pr`: verificar branch local == `headRefName` y working tree limpio ANTES del subagent. Si no, rollback + abortar.
 - Para `KIND=pr`: despues del subagent, si reporto ≥1 cambio aplicado: `git add -A && git commit -m "iterate(#$N): apply review feedback" && git push origin HEAD:$HEAD_REF`.
-- Para `KIND=issue`: el subagent escribe el nuevo body a `/tmp/cvm-iterate-new-body.md`; despues hacer `gh issue edit "$N" --body-file <path>`.
+- Para `KIND=issue`: el subagent escribe el nuevo body a `$ITER_TMP/new-body.md`; despues hacer `gh issue edit "$N" --body-file "$ITER_TMP/new-body.md"`.
 - Si commit/push o `gh issue edit` falla → rollback del lock + reportar error explicito al humano.
 - Aplicar post-transition (success o rollback) DESPUES de persistir cambios.
 - Usar `gh api` REST para labels (NO `gh issue edit --add-label` — REST evita scope `read:org`).
@@ -382,4 +393,4 @@ Luego, el **skill** (no el subagent) invoca `/r` usando el Skill tool para persi
 - No resolver review threads — el skill solo modifica codigo local + persiste.
 - No lanzar el agente si no quedaron comments accionables tras el filtrado.
 
-Nota: los archivos `/tmp/cvm-iterate-context.md` y `/tmp/cvm-iterate-diff.txt` los crea el **skill** como orquestacion (no cuentan como "archivos nuevos"). La restriccion "no crear archivos nuevos" aplica al **agente** despachado (ver prompt en Paso 5).
+Nota: los archivos `$ITER_TMP/context.md` y `$ITER_TMP/diff.txt` los crea el **skill** como orquestacion dentro del temp dir namespaced por PID (no cuentan como "archivos nuevos"). La restriccion "no crear archivos nuevos" aplica al **agente** despachado (ver prompt en Paso 5).

--- a/profiles/lite/skills/che-iterate/SKILL.md
+++ b/profiles/lite/skills/che-iterate/SKILL.md
@@ -1,4 +1,15 @@
-Aplica comments/reviews de un PR o issue lanzando un agente Opus con el contexto consolidado. `$ARGUMENTS` puede ser un numero (`/che-iterate 42`), una URL (`/che-iterate https://github.com/owner/repo/pull/42`), o vacio (`/che-iterate` usa la branch actual). El skill NO commitea — deja los cambios en el working tree para que el humano los revise. Aplica las transitions de la state machine `che:*` de che-cli en modo lenient (ver "Tagging" abajo).
+Aplica comments/reviews de un PR o issue lanzando un agente Opus con el contexto consolidado. `$ARGUMENTS` puede ser un numero (`/che-iterate 42`), una URL (`/che-iterate https://github.com/owner/repo/pull/42`), o vacio (`/che-iterate` usa la branch actual). El skill **persiste los cambios automaticamente**: para PR hace `git add -A && git commit && git push origin HEAD:<headRefName>`; para issue hace `gh issue edit --body-file`. Aplica las transitions de la state machine `che:*` de che-cli en modo lenient (ver "Tagging" abajo).
+
+## Contract
+
+Outputs observables que otros skills (especialmente `/che-loop`) pueden parsear con garantia de estabilidad. Cambiar estos strings es breaking change — sincronizar con consumers.
+
+- **Resumen final** (Paso 7): el reporte termina con un bloque que incluye literalmente la linea `Procesados por el agente: <Z>` donde `<Z>` es un entero (`0`, `1`, `2`, ...). Este es el campo parseable canonico para "cuantos comments aplico el iterate".
+  - `Z == 0` → no hubo cambios accionables / nada se commiteo (rollback aplicado).
+  - `Z >= 1` → hubo cambios; `git commit + push` (PR) o `gh issue edit` (issue) ya corrieron antes de retornar.
+- **Persistencia previa al return**: para `KIND=pr` con `Z >= 1`, el commit ya esta en `origin/<headRefName>` cuando el skill retorna. Para `KIND=issue` con `Z >= 1`, el body ya esta editado en GitHub. Es seguro lanzar `/che-validate` inmediatamente despues — vera el estado nuevo.
+- **Labels post-return**: aplica `che:executed` (PR) / `che:plan` (issue) en success, o vuelve a `che:validated` (rollback) si el agente reporto 0 aplicados o si la persistencia fallo. Leer label es deterministico; el resumen markdown es para el humano.
+- **Falla de persistencia**: si `git commit` / `git push` (PR) o `gh issue edit` (issue) falla, el resumen incluye explicitamente la palabra `failed` en la linea `Persistencia: ...` y el lock se rolleo a `che:validated`. El consumer (ej `/che-loop`) debe tratar esto como exit reason terminal — el humano resuelve a mano.
 
 ## Tagging (state machine de che-cli)
 
@@ -334,11 +345,11 @@ Iteracion sobre <PR|Issue> #<N> completada.
 - Filtrados (ruido/autor/APPROVED-vacio): <Y>
 - Procesados por el agente: <Z>
 - Archivos modificados (PR) / body actualizado (issue): <lista o "body de issue #<N>">
-- Persistencia: <commit + push <hash> a <branch> | gh issue edit OK | sin cambios>
+- Persistencia: <commit + push <hash> a <branch> | gh issue edit OK | sin cambios | failed: <detalle>>
 - Estado final: <che:executed|che:plan|che:validated (rollback)>
 ```
 
-Si hubo failure de commit/push o `gh issue edit`, dejar explicito que el lock se rolleo y que el humano debe reintentar a mano (con el detalle del error).
+Si hubo failure de commit/push o `gh issue edit`, la linea `Persistencia:` debe arrancar con `failed:` seguido del detalle del error (es el marcador parseable que el contrato expone). Ademas dejar explicito que el lock se rolleo y que el humano debe reintentar a mano.
 
 Luego, el **skill** (no el subagent) invoca `/r` usando el Skill tool para persistir aprendizajes de la sesion. Esto no contradice la restriccion "NO delegues a otros agentes" del prompt del agente: la restriccion aplica al subagent Opus despachado en el Paso 5; el orquestador (este skill) si puede invocar `/r`.
 

--- a/profiles/lite/skills/che-iterate/SKILL.md
+++ b/profiles/lite/skills/che-iterate/SKILL.md
@@ -86,7 +86,7 @@ Parsear el JSON resultante. Para cada comment / review, quedarse con: `id`, `use
 
 Descartar un comment / review si:
 
-- **Es del autor del PR/issue**: `user.login == AUTHOR`.
+- **Es del autor del PR/issue**: `user.login == AUTHOR` — **EXCEPTO** si el body (despues de hacer strip de `\s+` al inicio) empieza con `## Review:` (header canonico que `/che-validate` Paso 7 step 1 prepende a cada review machine-generated). Esa excepcion existe para que `/che-loop` componiendo `/che-validate` → `/che-iterate` bajo la misma `gh auth` no se canibalize a si mismo: las reviews del propio validate tienen el mismo `user.login` que el PR author, pero son feedback accionable y no ruido.
 - **Body puramente reaccional**, match case-insensitive contra el regex **despues de hacer strip de todo `\s+` (whitespace horizontal + newlines + tabs) al inicio y al final**:
   `^(lgtm|\+1|-1|👍|👎|🎉|🚀|thanks?|ty|nice|great|:\+1:|:-1:|:shipit:|:tada:|:rocket:)[.!]*$`
 - **Review con `state == APPROVED` y `body` vacio o solo whitespace**.
@@ -347,7 +347,7 @@ Luego, el **skill** (no el subagent) invoca `/r` usando el Skill tool para persi
 - **Validar que `N` matchea `^[0-9]+$` ANTES de pasarlo a cualquier comando shell** (`gh pr view "$N"`, `gh api .../issues/$N/...`, etc). Sin esa validacion, un input tipo `42;rm -rf ~` rompe la garantia de no-interpolacion.
 - Detectar PR vs issue con fallback `gh pr view` → `gh issue view`.
 - Usar `gh api --paginate` para los tres endpoints cuando `KIND=pr`, solo `issues/<N>/comments` cuando `KIND=issue`.
-- Filtrar comments del autor, reacciones puras (regex case-insensitive, **tras strip de `\s+` incluyendo newlines**), y reviews APPROVED vacios antes de pasar al agente.
+- Filtrar comments del autor (excepto si empiezan con `## Review:` — reviews machine-generated de `/che-validate`), reacciones puras (regex case-insensitive, **tras strip de `\s+` incluyendo newlines**), y reviews APPROVED vacios antes de pasar al agente.
 - Escribir el contexto a `/tmp/cvm-iterate-context.md` con Write tool; el prompt del agente referencia el path.
 - Dumpear el diff a `/tmp/cvm-iterate-diff.txt` **siempre**; inlinearlo en el contexto solo si tiene ≤ 2000 lineas. Si es mas grande, dejar solo el puntero al archivo.
 - Resolver `CURRENT_STATE` via stateref: PR labels primero, fallback a labels del issue linkeado (`closingIssuesReferences`).

--- a/profiles/lite/skills/che-loop/SKILL.md
+++ b/profiles/lite/skills/che-loop/SKILL.md
@@ -1,0 +1,264 @@
+Automatiza el ciclo `che-validate → che-iterate → che-validate → ...` sobre un PR o issue hasta que el verdict consolidado sea `approve`, no queden comments accionables, se alcance `--max N` iteraciones, o se detecte idempotencia (mismos comments dos iteraciones seguidas). `$ARGUMENTS` acepta el mismo formato que `/che-validate` y `/che-iterate`: numero (`24`), URL completa, `pr 24`, `issue 24`. Flag opcional `--max N` (default `3`). El skill **no toca labels `che:*` directamente** — eso lo hacen los skills internos via composicion (Skill tool).
+
+## Composicion (no reimplementar)
+
+Este skill es un orquestador puro. Invoca via Skill tool a:
+
+- `/che-validate` — para revisar y obtener verdict + labels `validated:*` / `plan-validated:*`.
+- `/che-iterate` — para aplicar comments accionables y persistir (PR: commit+push; issue: `gh issue edit --body-file`).
+
+NO duplica logica de fetch de comments, parseo de verdict, transitions de state machine, ni filtrado. Si algo del flujo `validate-iterate` cambia, se cambia en los skills internos, no aca.
+
+## Default `--max=3`
+
+Justificacion: en la practica, 3 iteraciones cubren los casos comunes (verdict `changes-requested` → fix → `approve`, con un buffer extra por si el primer fix es incompleto). Mas que eso suele indicar idempotencia (mismo comment vuelve) o un trade-off arquitectural que requiere humano. Mantener bajo evita gastar tokens y minutos de subagentes en loops poco productivos. Override con `--max N` si la tarea lo amerita.
+
+## Proceso
+
+### Paso 1: Parsear `$ARGUMENTS`
+
+Aceptar los mismos formatos que `/che-validate` y `/che-iterate`. Detectar y separar:
+
+- `--max N` (donde `N` matchea `^[0-9]+$` y `1 ≤ N ≤ 20`): si no matchea o esta fuera de rango, abortar: "Uso: `/che-loop <N | URL | pr N | issue N> [--max <1-20>]`". Default `MAX=3`.
+- Resto del input → `TARGET_INPUT` (lo que se pasa tal cual a `/che-validate` y `/che-iterate`).
+
+Si `TARGET_INPUT` queda vacio tras quitar el flag, abortar con mensaje de uso.
+
+**Validar regex `^[0-9]+$` para `N`** ANTES de pasarlo a cualquier comando shell. NUNCA interpolar `$ARGUMENTS` crudo en double-quoted shell.
+
+### Paso 2: Resolver target una vez (KIND + N + OWNER/REPO)
+
+Replicar el parseo de `/che-validate`/`/che-iterate` aca para evitar re-resolverlo en cada iteracion:
+
+1. **Precheck auth**: `gh auth status` una vez. Si falla, abortar: "gh no esta autenticado o no hay red — corre `gh auth login` y reintenta.".
+2. Parsear `TARGET_INPUT`:
+   - URL `https://github.com/<owner>/<repo>/(pull|issues)/<N>` → split por `/` localmente. NO interpolar la URL en shell.
+   - `pr N` / `issue N` (case-insensitive) → forzar KIND, `N` validado por regex.
+   - `^[0-9]+$` → `N`, KIND a detectar via fallback `gh pr view "$N"` → `gh issue view "$N"` (con `>/dev/null 2>&1` y separando exit code de stdout, igual que `/che-validate`).
+   - Cualquier otra cosa → abortar con uso.
+3. Si no vino URL, resolver `OWNER/REPO`:
+   ```bash
+   gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"' 2>/dev/null
+   ```
+4. Para `KIND=pr`: capturar `HEAD_REF` (`gh pr view "$N" $REPO_FLAG --json headRefName`) — se usa en Paso 4 (precheck PR) y para detectar push fallido.
+
+Guardar: `KIND` (`pr` | `issue`), `N`, `OWNER`, `REPO`, `HEAD_REF` (solo PR), `TARGET_INPUT_FOR_SKILLS` (string que se pasa intacto a `/che-validate` / `/che-iterate`; conviene canonicalizar a `pr N` o `issue N` para que los skills internos no tengan que volver a inferir KIND).
+
+### Paso 3: Precheck especifico para PR (working tree)
+
+Si `KIND=pr`:
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "$HEAD_REF" ]]; then
+  echo "Branch local '$CURRENT_BRANCH' != headRefName del PR '$HEAD_REF'."
+  echo "Hace 'git checkout $HEAD_REF' (o 'gh pr checkout $N') antes de /che-loop."
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree no limpio. Stashea o commitea antes de /che-loop."
+  exit 1
+fi
+```
+
+`/che-iterate` ya hace este check internamente y aborta — pero al fallar dentro del primer `/che-iterate` ya gastamos un `/che-validate`. Hacerlo arriba evita ese gasto.
+
+Para `KIND=issue` no hace falta — `/che-iterate` solo edita el body via `gh issue edit`.
+
+### Paso 4: Loop principal
+
+Inicializar:
+
+```
+ITER=0
+PREV_COMMENT_IDS=()      # set de IDs de la iteracion anterior (para idempotencia)
+LAST_VERDICT=""
+LAST_VALIDATE_URLS=()    # URLs de los comments posteados por el ultimo che-validate
+EXIT_REASON=""           # se llena al salir
+```
+
+Mientras `ITER < MAX`:
+
+#### 4.1 Incrementar y loggear
+
+```
+ITER=$((ITER + 1))
+echo "=== /che-loop iteracion $ITER de $MAX ==="
+```
+
+#### 4.2 Invocar `/che-validate`
+
+Via Skill tool: `Skill(skill: "che-validate", args: "$TARGET_INPUT_FOR_SKILLS")`.
+
+`/che-validate` se encarga de:
+- Lock `che:*ing` → fetch contexto → lanzar agentes → postear comments → consolidar verdict → aplicar `che:validated` + `<ns>:<verdict>`.
+
+Esperar a que termine. Si falla catastroficamente (todos los agentes failed), `/che-validate` ya hizo rollback del lock; en ese caso terminar el loop con `EXIT_REASON="validate-failed"` y reportar.
+
+Para que el orquestador del che-loop sepa el verdict aplicado, **usar el agente default de `/che-validate`** (Opus) leyendo despues el label aplicado:
+
+```bash
+# Determinar namespace
+if [[ "$KIND" == "pr" ]]; then NS=validated; else NS=plan-validated; fi
+
+# Leer labels actuales
+LABELS=$(gh api "repos/$OWNER/$REPO/issues/$N/labels" --jq '.[].name')
+
+VERDICT=""
+for v in approve changes-requested needs-human; do
+  if echo "$LABELS" | grep -qx "$NS:$v"; then VERDICT="$v"; break; fi
+done
+```
+
+Si `VERDICT` queda vacio (rollback de `/che-validate`), terminar con `EXIT_REASON="validate-no-verdict"`.
+
+Guardar `LAST_VERDICT=$VERDICT`.
+
+#### 4.3 Capturar URLs de las reviews recien posteadas
+
+Para el reporte final:
+
+```bash
+# Comments posteados en la iteracion: filtrar por timestamp posterior al inicio de la iteracion
+ITER_START_ISO=<timestamp ISO al inicio del 4.2>
+gh api --paginate "repos/$OWNER/$REPO/issues/$N/comments" \
+  --jq ".[] | select(.created_at >= \"$ITER_START_ISO\") | .html_url"
+```
+
+Guardar en `LAST_VALIDATE_URLS`.
+
+#### 4.4 Exit por verdict approve
+
+Si `VERDICT == approve`:
+- `EXIT_REASON="approved"`
+- Salir del loop.
+
+#### 4.5 Exit por verdict needs-human
+
+Si `VERDICT == needs-human`:
+- `EXIT_REASON="needs-human"`
+- Salir del loop. No iteramos: `/che-iterate` no resuelve trade-offs que requieren decision humana.
+
+#### 4.6 Caso `changes-requested`: detectar idempotencia
+
+Antes de invocar `/che-iterate`, fetch los comments accionables que `/che-iterate` veria y compararlos con la iteracion anterior:
+
+```bash
+# Mismos endpoints que /che-iterate Paso 2:
+gh api --paginate "repos/$OWNER/$REPO/issues/$N/comments" --jq '.[].id' > /tmp/cvm-loop-issue-ids.txt
+if [[ "$KIND" == "pr" ]]; then
+  gh api --paginate "repos/$OWNER/$REPO/pulls/$N/comments" --jq '.[].id' >> /tmp/cvm-loop-issue-ids.txt
+  gh api --paginate "repos/$OWNER/$REPO/pulls/$N/reviews" --jq '.[].id' >> /tmp/cvm-loop-issue-ids.txt
+fi
+sort -u /tmp/cvm-loop-issue-ids.txt > /tmp/cvm-loop-current-ids.txt
+```
+
+Aplicar el **mismo filtro barato** que `/che-iterate` Paso 3 (autor del PR/issue, reacciones puras, reviews APPROVED vacios). Como esto requiere mas que `id` (necesita `user.login`, `body`, `state`), en la practica fetch el JSON completo y filtrarlo localmente con `jq`. Para mantener este skill simple, **delegar el filtrado a la salida de `/che-iterate`** y comparar **antes** vs **despues**:
+
+Alternativa simpler (preferida): comparar los `id`s de comments **crudos** (sin filtrar). Si son iguales que la iteracion anterior, asumir idempotencia. Esto puede dar falsos positivos cuando un comment nuevo es 100% reaccional (ruido) — aceptable, porque el caso comun donde queremos detectar idempotencia es el reviewer dejando los mismos comentarios accionables sin que el commit los resuelva.
+
+```bash
+CURRENT_IDS=$(cat /tmp/cvm-loop-current-ids.txt)
+
+if [[ "$ITER" -gt 1 && "$CURRENT_IDS" == "$PREV_COMMENT_IDS" ]]; then
+  EXIT_REASON="idempotent"
+  break
+fi
+
+PREV_COMMENT_IDS="$CURRENT_IDS"
+```
+
+#### 4.7 Exit por 0 comments accionables
+
+Si `/che-iterate` no encontraria nada accionable (todos filtrados), no tiene sentido invocarlo. Detectarlo aca es costoso (replicar el filtrado). Estrategia mas simple: invocar `/che-iterate` igual y dejar que el reporte indique 0 aplicados → tratarlo como exit reason en 4.9.
+
+#### 4.8 Invocar `/che-iterate`
+
+Via Skill tool: `Skill(skill: "che-iterate", args: "$TARGET_INPUT_FOR_SKILLS")`.
+
+`/che-iterate` se encarga de:
+- Lock `che:*ing` → fetch + filtrar comments → lanzar agente Opus → editar codigo (PR) o body (issue) → **persistir** (PR: `git commit + git push`; issue: `gh issue edit --body-file`) → aplicar `che:executed` / `che:plan` (success) o rollback.
+
+Esperar a que termine.
+
+#### 4.9 Detectar 0 aplicados / fallo de iterate
+
+Leer el reporte de `/che-iterate`. Si el resumen indica:
+
+- "0 aplicados" / "no hay comments accionables" → `EXIT_REASON="no-actionable"`, salir.
+- Falla de commit/push (PR) o `gh issue edit` (issue) → `EXIT_REASON="iterate-persist-failed"`, salir. El humano resuelve a mano.
+- Fallo del subagent → `EXIT_REASON="iterate-failed"`, salir.
+
+Si `/che-iterate` fue exitoso (≥1 aplicado y persistido), volver al inicio del loop (Paso 4.1) — el siguiente `/che-validate` ya vera el commit nuevo (PR) o el body actualizado (issue) en GitHub.
+
+#### 4.10 Exit por `--max` alcanzado
+
+Si el `while` sale por `ITER == MAX` sin haber matcheado approve/needs-human/idempotent/no-actionable, `EXIT_REASON="max-iter"`.
+
+### Paso 5: Reporte final
+
+Mostrar al usuario:
+
+```
+/che-loop sobre <KIND> #<N> finalizado.
+
+Iteraciones ejecutadas: <ITER> de <MAX>
+Verdict final: <LAST_VERDICT o "(sin verdict)">
+Razon de salida: <EXIT_REASON>
+  - approved: el ultimo che-validate retorno verdict=approve.
+  - needs-human: subagent emitio needs-human; revisar a mano.
+  - changes-requested + max-iter: se acabaron las iteraciones con cambios pendientes.
+  - idempotent: dos iteraciones consecutivas con el mismo set de comments. Posible loop infinito — humano requerido.
+  - no-actionable: che-iterate no encontro nada accionable tras filtrado.
+  - iterate-persist-failed: commit/push o gh issue edit fallo. Reintenta a mano.
+  - iterate-failed / validate-failed / validate-no-verdict: skill interno fallo. Ver logs arriba.
+
+URLs de la ultima review:
+- <LAST_VALIDATE_URLS[0]>
+- ...
+
+Recomendacion:
+  - approved → listo para `/che-close <N>` (si KIND=pr).
+  - needs-human / idempotent → revisar comments a mano y decidir.
+  - max-iter / changes-requested → re-correr `/che-loop <N> --max N` con mas iteraciones, o `/che-iterate` manual.
+  - iterate-persist-failed → resolver el git/gh issue edit y reintentar.
+```
+
+No invocar `/r` automaticamente — cada `/che-validate` y `/che-iterate` interno ya decide su propia persistencia de learnings (en el caso de `/che-iterate`, llama a `/r` al final). El loop en si no genera learnings nuevos sobre el codebase.
+
+## MUST DO
+
+- Componer via Skill tool: invocar `/che-validate` y `/che-iterate`. NO duplicar logica de fetch de comments, filtrado, locks, transitions, ni parseo de verdict.
+- Parsear `--max N` con `^[0-9]+$` y rango `1 ≤ N ≤ 20`. Default `3`.
+- Validar `N` (numero del target) con `^[0-9]+$` ANTES de pasarlo a cualquier comando shell.
+- **Precheck PR**: si `KIND=pr`, verificar branch local == `HEAD_REF` y working tree limpio ANTES del primer `/che-validate` (evita gastar una validate cuando `/che-iterate` va a abortar igual).
+- Detectar `KIND` una sola vez (Paso 2) y reusarlo. No re-resolver en cada iteracion.
+- Leer el verdict de `/che-validate` desde los labels `validated:<v>` / `plan-validated:<v>` aplicados en GitHub (no parsear stdout del subagent — esos labels son el contrato persistido).
+- Detectar idempotencia comparando los `id`s de comments entre iteraciones consecutivas. Si son iguales tras `/che-iterate`, abortar con `EXIT_REASON=idempotent`.
+- Salir inmediatamente si `verdict=needs-human` (no iterar — requiere humano).
+- Salir si `/che-iterate` reporta 0 aplicados (no tiene sentido re-validar sin cambios).
+- Salir si `/che-iterate` falla en persistir (commit/push o `gh issue edit`) — el lock ya lo rolleo `/che-iterate`; reportar al humano para que resuelva a mano.
+- Reportar al final: iteraciones ejecutadas, verdict final, exit reason, URLs de la ultima review, recomendacion accionable.
+- Tolerar exit code 8 de `gh pr checks` si en algun momento se pollea CI (no aplica directamente aca, pero aplica si se compone con `/che-close` en el futuro).
+- Usar `gh api` REST para cualquier lectura de labels (mismo gotcha que el resto de los skills che-*).
+
+## MUST NOT DO
+
+- **No tocar labels `che:*` directamente.** Lo hacen `/che-validate` y `/che-iterate` internamente. El loop solo lee labels post-validate para extraer verdict.
+- No aplicar locks ni transitions propias del loop (`che:looping` no existe en la state machine de che-cli).
+- No commitear, no pushear, no editar bodies de issues directamente. `/che-iterate` lo hace.
+- No interpolar `$ARGUMENTS` ni el target del usuario en double-quoted shell. Pasar via Skill tool args (string) que el skill interno parsea con sus propias garantias.
+- No duplicar el filtrado de comments de `/che-iterate` Paso 3 — comparar idempotencia sobre IDs crudos es suficiente (acepta falsos positivos en favor de simplicidad).
+- No reintentar `/che-iterate` si fallo en persistir. El working tree puede quedar en estado raro; humano resuelve.
+- No correr el loop con `MAX > 20` — riesgo de quemar tokens/minutos en algo que un humano deberia mirar despues de 3-5.
+- No invocar `/r` al final del loop. Los skills internos ya manejan su propia persistencia.
+- No soportar GitLab/Bitbucket — solo GitHub via `gh`, igual que los hermanos.
+- No correr en paralelo `/che-validate` y `/che-iterate` — el loop es estrictamente secuencial (cada validate depende del commit/body del iterate anterior).
+
+## Notas de diseno
+
+- **Por que leer verdict de labels y no del stdout del Skill tool**: el Skill tool devuelve la salida del skill al orquestador, pero esa salida es markdown libre. Los labels `validated:*` / `plan-validated:*` son el contrato persistido en GitHub que `/che-validate` aplica antes de retornar — leerlos es deterministico y resiliente a cambios de formato del reporte.
+- **Por que comparar IDs crudos para idempotencia**: replicar el filtrado de `/che-iterate` Paso 3 aca acoplaria el loop a la implementacion interna del iterate. Comparar IDs crudos da false positives (ej: alguien dejo un `+1` nuevo entre iteraciones) que en la practica son raros y conservadores (preferimos abortar de mas que loopear de menos).
+- **Por que no soportar `KIND=issue` sin verdict ciclo**: para issues, `/che-iterate` reescribe el body — el siguiente `/che-validate` valida el body nuevo y si los reviewers dejaron mas comments, los aplica. El ciclo es identico al de PR conceptualmente; solo cambia el medio (body vs codigo).
+- **Por que `--max=3` y no `--max=5`**: 3 cubre el caso "primera review pidio cambios → fix → segunda review aprueba" con un buffer extra. 5 ya es zona donde la idempotencia o el needs-human son mas probables — preferimos cortar antes y que el humano decida. Override explicito si la tarea lo necesita.

--- a/profiles/lite/skills/che-loop/SKILL.md
+++ b/profiles/lite/skills/che-loop/SKILL.md
@@ -193,12 +193,22 @@ JQ_FILTER='.[] | (.body // "") | select((. | ltrimstr(" ") | ltrimstr("\n") | lt
 
 CURRENT_FP=$(shasum "$FINGERPRINT_FILE" | awk '{print $1}')
 
-if [[ "$ITER" -gt 1 && "$CURRENT_FP" == "$PREV_FP" ]]; then
-  EXIT_REASON="idempotent"
-  break
+# Guard: NO disparar idempotencia con set post-filtro vacio.
+# Caso autonomo (solo /che-validate como reviewer): tras excluir bodies que empiezan
+# con "## Review:", el set queda vacio en cada iteracion, y dos vacios consecutivos
+# hashean igual. Eso disparaba idempotencia falsa en iter 2 ANTES de invocar /che-iterate,
+# aunque el validate recien hubiera generado feedback nuevo y accionable.
+# Sin senal humana sobre la cual decidir idempotencia, dejamos que el loop avance
+# y que /che-iterate decida via "0 aplicados" si no hay nada que hacer (Paso 4.9).
+if [[ ! -s "$FINGERPRINT_FILE" ]]; then
+  PREV_FP="$CURRENT_FP"
+else
+  if [[ "$ITER" -gt 1 && "$CURRENT_FP" == "$PREV_FP" ]]; then
+    EXIT_REASON="idempotent"
+    break
+  fi
+  PREV_FP="$CURRENT_FP"
 fi
-
-PREV_FP="$CURRENT_FP"
 ```
 
 Esto da: false positives bajos (solo si dos sets distintos hashearan al mismo valor — extremadamente raro con SHA-1) y cubre el caso real (reviewer humano dejando los mismos comments accionables sin que el commit los resuelva). El loop sigue siendo conservador (preferimos abortar de mas que loopear de menos), pero ahora la senal **si dispara**.

--- a/profiles/lite/skills/che-loop/SKILL.md
+++ b/profiles/lite/skills/che-loop/SKILL.md
@@ -1,4 +1,4 @@
-Automatiza el ciclo `che-validate → che-iterate → che-validate → ...` sobre un PR o issue hasta que el verdict consolidado sea `approve`, no queden comments accionables, se alcance `--max N` iteraciones, o se detecte idempotencia (mismos comments dos iteraciones seguidas). `$ARGUMENTS` acepta el mismo formato que `/che-validate` y `/che-iterate`: numero (`24`), URL completa, `pr 24`, `issue 24`. Flag opcional `--max N` (default `3`). El skill **no toca labels `che:*` directamente** — eso lo hacen los skills internos via composicion (Skill tool).
+Automatiza el ciclo `che-validate → che-iterate → che-validate → ...` sobre un PR o issue hasta que el verdict consolidado sea `approve`, no queden comments accionables, se alcance `--max N` iteraciones, o se detecte idempotencia (fingerprint del feedback humano accionable repetido entre iteraciones). `$ARGUMENTS` acepta el mismo formato que `/che-validate` y `/che-iterate`: numero (`24`), URL completa, `pr 24`, `issue 24`. Flag opcional `--max N` (default `3`). El skill **no toca labels `che:*` directamente** — eso lo hacen los skills internos via composicion (Skill tool).
 
 ## Composicion (no reimplementar)
 
@@ -42,7 +42,16 @@ Replicar el parseo de `/che-validate`/`/che-iterate` aca para evitar re-resolver
    ```
 4. Para `KIND=pr`: capturar `HEAD_REF` (`gh pr view "$N" $REPO_FLAG --json headRefName`) — se usa en Paso 4 (precheck PR) y para detectar push fallido.
 
-Guardar: `KIND` (`pr` | `issue`), `N`, `OWNER`, `REPO`, `HEAD_REF` (solo PR), `TARGET_INPUT_FOR_SKILLS` (string que se pasa intacto a `/che-validate` / `/che-iterate`; conviene canonicalizar a `pr N` o `issue N` para que los skills internos no tengan que volver a inferir KIND).
+Guardar: `KIND` (`pr` | `issue`), `N`, `OWNER`, `REPO`, `HEAD_REF` (solo PR), `TARGET_INPUT_FOR_SKILLS` (string que se pasa intacto a `/che-validate` / `/che-iterate`).
+
+**Reglas para `TARGET_INPUT_FOR_SKILLS`** (importante para soportar cross-repo):
+
+- Si el input vino como **URL** completa (`https://github.com/<owner>/<repo>/(pull|issues)/<N>`): **mantener la URL tal cual**. No canonicalizar a `pr N` / `issue N` — los skills internos solo preservan el repo ajeno cuando reciben la URL completa; con `pr N` re-resuelven `gh repo view` y caen en el repo actual del cwd, que NO es necesariamente el target.
+- Si el input vino como `pr N` / `issue N` o numero puro: detectar si `OWNER/REPO` resuelto coincide con el repo del cwd actual (`gh repo view --json owner,name`):
+  - Coincide → canonicalizar a `pr N` / `issue N` (mas legible para los skills internos).
+  - No coincide (caso raro: `gh` apuntando a otro repo via env/flags) → usar la URL `https://github.com/<OWNER>/<REPO>/(pull|issues)/<N>` para preservar el contexto.
+
+En resumen: el orquestador **nunca degrada** una URL cross-repo a forma corta. Esto evita que `/che-validate`/`/che-iterate` operen contra el repo equivocado.
 
 ### Paso 3: Precheck especifico para PR (working tree)
 
@@ -64,6 +73,8 @@ fi
 
 `/che-iterate` ya hace este check internamente y aborta — pero al fallar dentro del primer `/che-iterate` ya gastamos un `/che-validate`. Hacerlo arriba evita ese gasto.
 
+> **Duplicado deliberado**: este precheck replica `/che-iterate` Paso 4.6. Si el contrato de `/che-iterate` cambia (ej: aprende a `git stash` automaticamente, deja de exigir branch == `headRefName`), sincronizar este Paso 3 a mano. La duplicacion es un trade-off explicito (DRY vs short-circuit antes de gastar una validate); preferimos short-circuit.
+
 Para `KIND=issue` no hace falta — `/che-iterate` solo edita el body via `gh issue edit`.
 
 ### Paso 4: Loop principal
@@ -72,10 +83,11 @@ Inicializar:
 
 ```
 ITER=0
-PREV_COMMENT_IDS=()      # set de IDs de la iteracion anterior (para idempotencia)
+PREV_FP=""               # fingerprint (sha) del feedback accionable de la iter anterior, para idempotencia
 LAST_VERDICT=""
 LAST_VALIDATE_URLS=()    # URLs de los comments posteados por el ultimo che-validate
 EXIT_REASON=""           # se llena al salir
+LOOP_TMP=$(mktemp -d -t cvm-loop-XXXXXX)   # paths del loop, namespaced por PID — no choquea con runs concurrentes
 ```
 
 Mientras `ITER < MAX`:
@@ -93,6 +105,8 @@ Via Skill tool: `Skill(skill: "che-validate", args: "$TARGET_INPUT_FOR_SKILLS")`
 
 `/che-validate` se encarga de:
 - Lock `che:*ing` → fetch contexto → lanzar agentes → postear comments → consolidar verdict → aplicar `che:validated` + `<ns>:<verdict>`.
+
+> **Convencion de interactividad**: `/che-validate` puede pedir al usuario que elija agentes (prompt `[O/c/g/a]`). Cuando se invoca desde `/che-loop`, **el orquestador del loop responde automaticamente con el default (Opus solo)** — no detiene la ejecucion para preguntar. Esto se logra dejando que el Skill tool propague la respuesta vacia / aceptando default. Si en el futuro se quiere un agente distinto en cada iteracion, agregar una flag al loop (ej `--agents O,c`) y forwardearlo al validate; por ahora, todos los validates dentro de un loop usan Opus.
 
 Esperar a que termine. Si falla catastroficamente (todos los agentes failed), `/che-validate` ya hizo rollback del lock; en ese caso terminar el loop con `EXIT_REASON="validate-failed"` y reportar.
 
@@ -142,32 +156,54 @@ Si `VERDICT == needs-human`:
 
 #### 4.6 Caso `changes-requested`: detectar idempotencia
 
-Antes de invocar `/che-iterate`, fetch los comments accionables que `/che-iterate` veria y compararlos con la iteracion anterior:
+Antes de invocar `/che-iterate`, computar un fingerprint **estable** del feedback accionable y compararlo con el de la iteracion anterior. Detalles importantes:
+
+- **Los IDs crudos NO sirven**: `/che-validate` postea comments nuevos en cada iteracion del loop (header `## Review: <agent>`), asi que el set de IDs cambia siempre, aunque el feedback semantico del reviewer humano sea identico. Comparar IDs nunca dispararia idempotencia en el caso real.
+- **Senal correcta: hash del body de los comments accionables, excluyendo los del propio `/che-validate`.** Filtramos los comments cuyo body (despues de strip de whitespace al inicio) empieza con `## Review:` — esos los genera `/che-validate` y son los que cambian entre iteraciones. Lo que queda es el feedback del reviewer humano (o de otros bots), que es lo que iterate va a procesar.
+
+Usamos `$LOOP_TMP` (creado al inicializar el loop con `mktemp -d`) — los paths quedan **namespaced por PID** y no chocan con runs concurrentes (a diferencia de los `/tmp/cvm-loop-*.txt` globales que tenia la version anterior).
 
 ```bash
-# Mismos endpoints que /che-iterate Paso 2:
-gh api --paginate "repos/$OWNER/$REPO/issues/$N/comments" --jq '.[].id' > /tmp/cvm-loop-issue-ids.txt
-if [[ "$KIND" == "pr" ]]; then
-  gh api --paginate "repos/$OWNER/$REPO/pulls/$N/comments" --jq '.[].id' >> /tmp/cvm-loop-issue-ids.txt
-  gh api --paginate "repos/$OWNER/$REPO/pulls/$N/reviews" --jq '.[].id' >> /tmp/cvm-loop-issue-ids.txt
-fi
-sort -u /tmp/cvm-loop-issue-ids.txt > /tmp/cvm-loop-current-ids.txt
+FINGERPRINT_FILE="$LOOP_TMP/fp-iter-$ITER.txt"
 ```
 
-Aplicar el **mismo filtro barato** que `/che-iterate` Paso 3 (autor del PR/issue, reacciones puras, reviews APPROVED vacios). Como esto requiere mas que `id` (necesita `user.login`, `body`, `state`), en la practica fetch el JSON completo y filtrarlo localmente con `jq`. Para mantener este skill simple, **delegar el filtrado a la salida de `/che-iterate`** y comparar **antes** vs **despues**:
-
-Alternativa simpler (preferida): comparar los `id`s de comments **crudos** (sin filtrar). Si son iguales que la iteracion anterior, asumir idempotencia. Esto puede dar falsos positivos cuando un comment nuevo es 100% reaccional (ruido) — aceptable, porque el caso comun donde queremos detectar idempotencia es el reviewer dejando los mismos comentarios accionables sin que el commit los resuelva.
+Fetch el **JSON completo** (no solo `.id`) de los tres endpoints:
 
 ```bash
-CURRENT_IDS=$(cat /tmp/cvm-loop-current-ids.txt)
+gh api --paginate "repos/$OWNER/$REPO/issues/$N/comments" > "$LOOP_TMP/issue-comments.json"
+if [[ "$KIND" == "pr" ]]; then
+  gh api --paginate "repos/$OWNER/$REPO/pulls/$N/comments" > "$LOOP_TMP/pr-comments.json"
+  gh api --paginate "repos/$OWNER/$REPO/pulls/$N/reviews"  > "$LOOP_TMP/pr-reviews.json"
+fi
+```
 
-if [[ "$ITER" -gt 1 && "$CURRENT_IDS" == "$PREV_COMMENT_IDS" ]]; then
+Computar fingerprint con `jq`: filtrar los comments con body que empieza por `## Review:` (machine-generated por `/che-validate`), tomar el body crudo del resto, ordenar y hashear:
+
+```bash
+# jq filter: el body crudo si NO empieza con "## Review:" (tras strip), vacio si si empieza
+JQ_FILTER='.[] | (.body // "") | select((. | ltrimstr(" ") | ltrimstr("\n") | ltrimstr("\t") | startswith("## Review:")) | not)'
+
+{
+  jq -r "$JQ_FILTER" "$LOOP_TMP/issue-comments.json"
+  if [[ "$KIND" == "pr" ]]; then
+    jq -r "$JQ_FILTER" "$LOOP_TMP/pr-comments.json"
+    jq -r "$JQ_FILTER" "$LOOP_TMP/pr-reviews.json"
+  fi
+} | sort > "$FINGERPRINT_FILE"
+
+CURRENT_FP=$(shasum "$FINGERPRINT_FILE" | awk '{print $1}')
+
+if [[ "$ITER" -gt 1 && "$CURRENT_FP" == "$PREV_FP" ]]; then
   EXIT_REASON="idempotent"
   break
 fi
 
-PREV_COMMENT_IDS="$CURRENT_IDS"
+PREV_FP="$CURRENT_FP"
 ```
+
+Esto da: false positives bajos (solo si dos sets distintos hashearan al mismo valor — extremadamente raro con SHA-1) y cubre el caso real (reviewer humano dejando los mismos comments accionables sin que el commit los resuelva). El loop sigue siendo conservador (preferimos abortar de mas que loopear de menos), pero ahora la senal **si dispara**.
+
+> Nota: el filtro `## Review:` aca es el mismo que `/che-iterate` Paso 3 usa para preservar reviews machine-generated. Aca lo invertimos (las excluimos del fingerprint) porque queremos detectar si el feedback **del reviewer**, no del propio loop, se repite. Si el contrato del header `## Review:` cambia en `/che-validate`, sincronizar aca tambien.
 
 #### 4.7 Exit por 0 comments accionables
 
@@ -184,19 +220,40 @@ Esperar a que termine.
 
 #### 4.9 Detectar 0 aplicados / fallo de iterate
 
-Leer el reporte de `/che-iterate`. Si el resumen indica:
+Leer el reporte de `/che-iterate` parseando el contrato formalizado en su `## Contract` section. Las dos senales canonicas son:
 
-- "0 aplicados" / "no hay comments accionables" → `EXIT_REASON="no-actionable"`, salir.
-- Falla de commit/push (PR) o `gh issue edit` (issue) → `EXIT_REASON="iterate-persist-failed"`, salir. El humano resuelve a mano.
-- Fallo del subagent → `EXIT_REASON="iterate-failed"`, salir.
+1. **Linea `Procesados por el agente: <Z>`** — `Z` es entero. Lo extraemos con un grep simple (no parse de markdown):
+   ```bash
+   ITERATE_OUTPUT=<stdout del Skill tool>
+   APPLIED=$(echo "$ITERATE_OUTPUT" | grep -E '^- Procesados por el agente: [0-9]+$' | tail -1 | grep -oE '[0-9]+$')
+   ```
+   - `APPLIED == 0` → `EXIT_REASON="no-actionable"`, salir.
+   - `APPLIED >= 1` → continuar al chequeo de persistencia.
+   - `APPLIED` vacio (no se encontro la linea — contrato roto) → `EXIT_REASON="iterate-failed"`, salir y warnear al humano.
 
-Si `/che-iterate` fue exitoso (≥1 aplicado y persistido), volver al inicio del loop (Paso 4.1) — el siguiente `/che-validate` ya vera el commit nuevo (PR) o el body actualizado (issue) en GitHub.
+2. **Linea `Persistencia: ...`** — si arranca con `failed:` (segun el contrato), la persistencia fallo aunque haya cambios:
+   ```bash
+   if echo "$ITERATE_OUTPUT" | grep -qE '^- Persistencia: failed:'; then
+     EXIT_REASON="iterate-persist-failed"
+     break
+   fi
+   ```
+
+Si `APPLIED >= 1` y `Persistencia` no es `failed:`, `/che-iterate` fue exitoso → volver al inicio del loop (Paso 4.1). El siguiente `/che-validate` vera el commit nuevo (PR) o el body actualizado (issue) en GitHub (el contrato garantiza persistencia previa al return).
+
+> **Por que parsear contrato en vez de frases libres**: la version anterior buscaba "0 aplicados" / "no hay comments accionables" en el resumen markdown. Eso es fragil: cualquier cambio de wording en `/che-iterate` (refactor, traduccion, etc) rompe el loop silenciosamente. El bloque `## Contract` de `/che-iterate` documenta los strings exactos como contrato estable y obliga a sincronizar consumers en cualquier breaking change.
 
 #### 4.10 Exit por `--max` alcanzado
 
 Si el `while` sale por `ITER == MAX` sin haber matcheado approve/needs-human/idempotent/no-actionable, `EXIT_REASON="max-iter"`.
 
 ### Paso 5: Reporte final
+
+Antes de imprimir, leer el `che:*` actual del target para reportar state final accurate (especialmente util en `max-iter`):
+
+```bash
+FINAL_STATE=$(gh api "repos/$OWNER/$REPO/issues/$N/labels" --jq '.[].name' | grep -E '^che:' | head -1)
+```
 
 Mostrar al usuario:
 
@@ -205,6 +262,7 @@ Mostrar al usuario:
 
 Iteraciones ejecutadas: <ITER> de <MAX>
 Verdict final: <LAST_VERDICT o "(sin verdict)">
+Estado final: <FINAL_STATE o "(sin che:*)">
 Razon de salida: <EXIT_REASON>
   - approved: el ultimo che-validate retorno verdict=approve.
   - needs-human: subagent emitio needs-human; revisar a mano.
@@ -235,7 +293,10 @@ No invocar `/r` automaticamente — cada `/che-validate` y `/che-iterate` intern
 - **Precheck PR**: si `KIND=pr`, verificar branch local == `HEAD_REF` y working tree limpio ANTES del primer `/che-validate` (evita gastar una validate cuando `/che-iterate` va a abortar igual).
 - Detectar `KIND` una sola vez (Paso 2) y reusarlo. No re-resolver en cada iteracion.
 - Leer el verdict de `/che-validate` desde los labels `validated:<v>` / `plan-validated:<v>` aplicados en GitHub (no parsear stdout del subagent — esos labels son el contrato persistido).
-- Detectar idempotencia comparando los `id`s de comments entre iteraciones consecutivas. Si son iguales tras `/che-iterate`, abortar con `EXIT_REASON=idempotent`.
+- Detectar idempotencia hasheando el body de los comments accionables (excluyendo los machine-generated por `/che-validate` con header `## Review:`) entre iteraciones consecutivas. Si el fingerprint repite, abortar con `EXIT_REASON=idempotent`.
+- Mantener URLs cross-repo intactas en `TARGET_INPUT_FOR_SKILLS`: nunca degradar una URL completa a `pr N` / `issue N` cuando el repo del target no es el del cwd.
+- Usar `mktemp -d` para los archivos temporales del loop. NUNCA paths globales tipo `/tmp/cvm-loop-*.txt` (corrompen runs concurrentes).
+- Parsear el output de `/che-iterate` segun su `## Contract` section (linea `Procesados por el agente: <Z>` y `Persistencia: ...`). NUNCA buscar frases libres como "0 aplicados" en el resumen markdown.
 - Salir inmediatamente si `verdict=needs-human` (no iterar — requiere humano).
 - Salir si `/che-iterate` reporta 0 aplicados (no tiene sentido re-validar sin cambios).
 - Salir si `/che-iterate` falla en persistir (commit/push o `gh issue edit`) — el lock ya lo rolleo `/che-iterate`; reportar al humano para que resuelva a mano.
@@ -249,16 +310,26 @@ No invocar `/r` automaticamente — cada `/che-validate` y `/che-iterate` intern
 - No aplicar locks ni transitions propias del loop (`che:looping` no existe en la state machine de che-cli).
 - No commitear, no pushear, no editar bodies de issues directamente. `/che-iterate` lo hace.
 - No interpolar `$ARGUMENTS` ni el target del usuario en double-quoted shell. Pasar via Skill tool args (string) que el skill interno parsea con sus propias garantias.
-- No duplicar el filtrado de comments de `/che-iterate` Paso 3 — comparar idempotencia sobre IDs crudos es suficiente (acepta falsos positivos en favor de simplicidad).
+- No duplicar el filtrado completo de comments de `/che-iterate` Paso 3 — para idempotencia alcanza con hashear bodies excluyendo los `## Review:` (es decir, lo que el reviewer humano dijo, no lo que el propio loop posteo).
+- No buscar frases libres ("0 aplicados", "no hay comments accionables") en el output de `/che-iterate`. Usar el contrato formal (`## Contract` section).
 - No reintentar `/che-iterate` si fallo en persistir. El working tree puede quedar en estado raro; humano resuelve.
 - No correr el loop con `MAX > 20` — riesgo de quemar tokens/minutos en algo que un humano deberia mirar despues de 3-5.
 - No invocar `/r` al final del loop. Los skills internos ya manejan su propia persistencia.
 - No soportar GitLab/Bitbucket — solo GitHub via `gh`, igual que los hermanos.
 - No correr en paralelo `/che-validate` y `/che-iterate` — el loop es estrictamente secuencial (cada validate depende del commit/body del iterate anterior).
+- **No asumir aislamiento entre iteraciones del loop.** Entre la salida de `/che-iterate` (`che:executed` / `che:plan`) y la entrada del proximo `/che-validate` (`che:executed→che:validating`), hay una ventana sin lock. Un humano puede correr `/che-validate` o `/che-iterate` manualmente justo en esa ventana sin que el loop se entere. El peor caso es que el loop detecte una iteracion extra via idempotencia (mismo fingerprint) y salga limpio — no hay corrupcion de estado, solo una iteracion gastada de mas.
 
 ## Notas de diseno
 
 - **Por que leer verdict de labels y no del stdout del Skill tool**: el Skill tool devuelve la salida del skill al orquestador, pero esa salida es markdown libre. Los labels `validated:*` / `plan-validated:*` son el contrato persistido en GitHub que `/che-validate` aplica antes de retornar — leerlos es deterministico y resiliente a cambios de formato del reporte.
-- **Por que comparar IDs crudos para idempotencia**: replicar el filtrado de `/che-iterate` Paso 3 aca acoplaria el loop a la implementacion interna del iterate. Comparar IDs crudos da false positives (ej: alguien dejo un `+1` nuevo entre iteraciones) que en la practica son raros y conservadores (preferimos abortar de mas que loopear de menos).
+- **Por que hashear bodies (no IDs) para idempotencia**: `/che-validate` postea comments nuevos en cada iteracion, asi que los IDs cambian aunque el feedback semantico sea identico. Comparar IDs nunca dispararia. Hashear el body de los comments accionables (excluyendo los `## Review:` del propio loop) detecta el caso real: el reviewer dejo los mismos comentarios accionables y el commit no los resolvio. False positives son extremadamente raros (colision de SHA-1).
 - **Por que no soportar `KIND=issue` sin verdict ciclo**: para issues, `/che-iterate` reescribe el body — el siguiente `/che-validate` valida el body nuevo y si los reviewers dejaron mas comments, los aplica. El ciclo es identico al de PR conceptualmente; solo cambia el medio (body vs codigo).
 - **Por que `--max=3` y no `--max=5`**: 3 cubre el caso "primera review pidio cambios → fix → segunda review aprueba" con un buffer extra. 5 ya es zona donde la idempotencia o el needs-human son mas probables — preferimos cortar antes y que el humano decida. Override explicito si la tarea lo necesita.
+- **Por que existe en lite y no en che-cli**: che-cli es un CLI con humans-in-the-loop deliberado entre cada step (`che validate`, `che iterate` corren en shells humanas). El profile lite corre dentro de una sesion Claude Code donde el agente humano ya esta presente y dispuesto a delegar tareas batch. El loop tiene sentido aca porque el costo marginal de una iteracion es bajo (subagent paralelo) y el costo de espera humana entre `validate→iterate→validate` es alto (context switch). En CLI, "loop" = humano corriendo dos comandos, no hace falta automatizar; en lite, "loop" = humano esperando subagentes, automatizar paga. Por eso `che:looping` no existe en `che-cli/internal/labels/labels.go` y este skill no lo introduce — control flow del orquestador, no estado del issue/PR.
+- **Estado final post-loop (segun exit reason)**:
+  - `EXIT_REASON=approved` → state final `che:validated` (el ultimo paso fue `/che-validate` que aplico approve y no se invoco iterate).
+  - `EXIT_REASON=needs-human` → state final `che:validated` con verdict `needs-human` (igual: ultimo paso fue validate).
+  - `EXIT_REASON=no-actionable` → state final `che:validated` (ultimo paso fue iterate con 0 aplicados → rollback).
+  - `EXIT_REASON=idempotent` → state final `che:validated` (idempotencia se detecta antes de invocar iterate).
+  - `EXIT_REASON=max-iter` → state final depende: si la ultima iteracion del while fue iterate exitoso, queda `che:executed` (PR) / `che:plan` (issue); si fue validate sin iterate, queda `che:validated`. **Reportar el state final explicito en el Paso 5 leyendo el label actual antes de salir.**
+  - `EXIT_REASON=iterate-persist-failed` / `iterate-failed` / `validate-failed` / `validate-no-verdict` → state final segun el rollback que el skill interno haya aplicado (tipicamente `che:validated`).

--- a/profiles/lite/skills/che-validate/SKILL.md
+++ b/profiles/lite/skills/che-validate/SKILL.md
@@ -1,5 +1,13 @@
 Revisar un PR o issue de GitHub lanzando agentes seleccionados en paralelo (opus/codex/gemini), posteando cada review como comment separado, y aplicando las transitions de la state machine `che:*` de che-cli en modo lenient. $ARGUMENTS es el PR/issue a revisar: numero (`24`), URL completa, o `pr 24` / `issue 24`.
 
+## Contract
+
+Outputs observables que otros skills (especialmente `/che-loop`) componen y dependen de su estabilidad. Cambiar estos strings/comportamientos es breaking change — sincronizar con consumers.
+
+- **Modo non-interactive (default Opus)**: el Paso 4 muestra el prompt `Que agentes? [O/c/g/a] (default: O):`. Cuando se invoca desde un orquestador (ej. `/che-loop`) sin respuesta humana, la entrada vacia se trata como aceptacion del default → `AGENTS=[opus]`. Ese contrato permite componer `/che-validate` en cadena sin que el prompt bloquee. Si se necesita otro agente desde un orquestador, hay que extender la API del skill (ej. flag explicito `--agents O,c`) y forwardearlo desde el caller; mientras tanto, default-Opus es el unico modo non-interactive estable.
+- **Header canonico de cada review**: cada comment posteado en el Paso 7 arranca **literalmente** con `## Review: <agente> (<perspectiva>)` (ver Paso 7 step 1). Ese prefijo es contract estable — `/che-iterate` Paso 3 lo usa como excepcion al filtro de autor (no descarta reviews machine-generated del propio bot), y `/che-loop` Paso 4.6 lo usa para excluir reviews del fingerprint de idempotencia. Cambiar ese formato rompe ambos consumers silenciosamente.
+- **Verdict label persistido**: el Paso 7.6.a aplica `<VERDICT_NS>:<verdict>` (`validated:approve` / `validated:changes-requested` / `validated:needs-human` para PR; `plan-validated:*` para issue) ANTES de retornar al caller. Leer ese label es la forma deterministica de obtener el verdict (no parsear stdout). En rollback (todos los agentes fallaron) NO se aplica verdict label — el consumer debe distinguir "sin verdict label" como senal de fallo.
+
 ## Tagging (state machine de che-cli)
 
 Aplica las transitions de `che-cli/internal/labels/labels.go`:


### PR DESCRIPTION
Implementa #29.

Closes #29

## Notas del agente

# EXEC_NOTES — issue #29 (`/che-loop`)

## Lo que se hizo

- Nuevo skill `profiles/lite/skills/che-loop/SKILL.md` (264 lineas).
- Nueva fila `/che-loop` en `profiles/lite/CLAUDE.md`, ubicada entre `/che-iterate` y `/che-close` (orden logico del flujo: validate → iterate → loop sobre ambos → close).
- Texto del bullet "los 6 skills che" actualizado: ahora distingue los 6 que tocan state machine vs `/che-loop` que es orquestador puro.
- `profiles/lite/install.sh` NO se modifico — ya itera `*/SKILL.md` automaticamente y va a sincronizar `che-loop` al redeploy.

## Decisiones de diseno destacadas

1. **Composicion via Skill tool, no reimplementacion.** El skill invoca `/che-validate` y `/che-iterate` directamente. Cualquier cambio futuro en el filtrado de comments, fetch o transitions vive en los hermanos, no aca.
2. **Lectura del verdict desde labels (`validated:*` / `plan-validated:*`), no del stdout del Skill tool.** Los labels son el contrato persistido en GitHub que `/che-validate` aplica al final; leerlos es deterministico y resiliente al formato del reporte.
3. **No tocar `che:*` directamente.** El loop no aplica locks ni transitions propias — `che:looping` no existe en la state machine de che-cli (`labels.go`). Documentado en MUST NOT DO.
4. **Idempotencia por IDs crudos de comments.** Comparar IDs sin filtrar puede dar false positives (ej: alguien dejo un `+1` nuevo) pero evita acoplar el loop al filtrado interno de `/che-iterate`. Conservador en favor de simplicidad.
5. **`--max=3` default.** Cubre "primera review pide cambios → fix → segunda review aprueba" con buffer extra. Mas que eso suele indicar idempotencia o needs-human. Override explicito disponible (rango `1 <= N <= 20`).
6. **Salida inmediata en `needs-human`.** No iteramos; `/che-iterate` no resuelve trade-offs que requieren decision humana.
7. **Precheck de PR (branch == headRefName + working tree limpio) ANTES del primer `/che-validate`.** `/che-iterate` ya aborta si esto no se cumple, pero hacerlo arriba evita gastar una validate. Para issues no aplica.

## Dual location (`~/.claude/skills/`)

Segun la memoria `lite_profile_dual_location.md`, los skills viven tanto en `~/.claude/skills/` (runtime) como en `profiles/lite/skills/` (fuente del repo). En este worktree solo se modifico la fuente del repo. El sync a `~/.claude/skills/che-loop/SKILL.md` lo hace `cvm install` / `bash profiles/lite/install.sh` post-merge.

## Pendiente

Nada bloqueante. La verificacion end-to-end del loop (validate → iterate → validate sobre un PR real con cambios pedidos) requiere correrlo despues del merge, idealmente sobre un PR de prueba con comments accionables.

## Validacion ejecutada en este run

- No hay markdown linter ni skill validator en el repo (`Makefile` solo corre `go test`).
- Frontmatter consistente con los hermanos: primera linea es la descripcion en una sola oracion (ningun skill del profile lite usa YAML frontmatter).
- `install.sh` no requiere cambios — usa glob `*/SKILL.md` y picks up `che-loop` automaticamente.
