### PR TITLE
Add manifest-backed harness resolution for profiles

### DIFF
--- a/cmd/override.go
+++ b/cmd/override.go
@@ -272,10 +272,6 @@ var overrideSetCmd = &cobra.Command{
 		var src string
 		if extra, ok := claude.ExternalManagedPath(scope, projectPath); ok && filename == extra.ProfilePath {
 			src = extra.LivePath
-		} else if filename == ".claude.json" && scope == config.ScopeGlobal {
-			if extra, ok := claude.ExternalManagedPath(config.ScopeGlobal, ""); ok {
-				src = extra.LivePath
-			}
 		} else {
 			src = filepath.Join(liveDir, filename)
 		}
@@ -289,9 +285,6 @@ var overrideSetCmd = &cobra.Command{
 			}
 		}
 		if extra, ok := claude.ExternalManagedPath(scope, projectPath); ok && filename == extra.ProfilePath {
-			known = true
-		}
-		if filename == ".claude.json" && scope == config.ScopeGlobal {
 			known = true
 		}
 		if !known {

--- a/cmd/override.go
+++ b/cmd/override.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/chichex/cvm/internal/config"
+	"github.com/chichex/cvm/internal/harness"
 	"github.com/chichex/cvm/internal/profile"
 	"github.com/chichex/cvm/internal/state"
 	"github.com/spf13/cobra"
@@ -257,34 +258,40 @@ var overrideSetCmd = &cobra.Command{
 			return fmt.Errorf(".mcp.json is only valid for local profiles — use .claude.json for global profiles")
 		}
 
+		claude := harness.Claude()
+
 		// Determine live directory
 		var liveDir string
 		if scope == config.ScopeGlobal {
-			liveDir = config.ClaudeHome()
+			liveDir = claude.TargetDir(config.ScopeGlobal, "")
 		} else {
-			liveDir = config.ProjectClaudeDir(projectPath)
+			liveDir = claude.TargetDir(config.ScopeLocal, projectPath)
 		}
 
 		// Find the correct source file path
 		var src string
-		if filename == ".claude.json" {
-			// Special case: .claude.json lives at ~/.claude.json (not inside ~/.claude/)
-			src = config.ClaudeUserConfigPath()
-		} else if filename == ".mcp.json" {
-			src = config.ProjectMCPConfigPath(projectPath)
+		if extra, ok := claude.ExternalManagedPath(scope, projectPath); ok && filename == extra.ProfilePath {
+			src = extra.LivePath
+		} else if filename == ".claude.json" && scope == config.ScopeGlobal {
+			if extra, ok := claude.ExternalManagedPath(config.ScopeGlobal, ""); ok {
+				src = extra.LivePath
+			}
 		} else {
 			src = filepath.Join(liveDir, filename)
 		}
 
 		// Validate it is a known managed item and that it's a file, not a directory
 		known := false
-		for _, item := range config.ManagedClaudeDirItems {
+		for _, item := range claude.ManagedDirItems() {
 			if item == filename {
 				known = true
 				break
 			}
 		}
-		if filename == ".claude.json" || filename == ".mcp.json" {
+		if extra, ok := claude.ExternalManagedPath(scope, projectPath); ok && filename == extra.ProfilePath {
+			known = true
+		}
+		if filename == ".claude.json" && scope == config.ScopeGlobal {
 			known = true
 		}
 		if !known {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/chichex/cvm/internal/config"
+	"github.com/chichex/cvm/internal/harness"
 	"github.com/chichex/cvm/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -23,7 +24,7 @@ var statusCmd = &cobra.Command{
 		if globalProfile == "" {
 			globalProfile = "(vanilla)"
 		}
-		fmt.Printf("Global:  %-20s  → %s\n", globalProfile, config.ClaudeHome())
+		fmt.Printf("Global:  %-20s  → %s\n", globalProfile, harness.Claude().TargetDir(config.ScopeGlobal, ""))
 
 		// Local
 		cwd, _ := os.Getwd()
@@ -31,7 +32,7 @@ var statusCmd = &cobra.Command{
 		if localProfile == "" {
 			localProfile = "(vanilla)"
 		}
-		fmt.Printf("Local:   %-20s  → %s/.claude\n", localProfile, cwd)
+		fmt.Printf("Local:   %-20s  → %s\n", localProfile, harness.Claude().TargetDir(config.ScopeLocal, cwd))
 
 		return nil
 	},

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -244,6 +244,50 @@ func TestStatus(t *testing.T) {
 	assertContains(t, out, "statustest")
 }
 
+func TestUseSupportsManifestBackedClaudeProfile(t *testing.T) {
+	e := newTestEnv(t)
+	e.seedGlobalClaude("# vanilla")
+
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "manifested")
+	if err := os.MkdirAll(filepath.Join(profileRoot, "claude"), 0755); err != nil {
+		t.Fatalf("mkdir manifest profile: %v", err)
+	}
+	manifest := "name = \"manifested\"\nharnesses = [\"claude\"]\n\n[assets]\nclaude = \"claude\"\n"
+	if err := os.WriteFile(filepath.Join(profileRoot, "cvm.profile.toml"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(profileRoot, "claude", "CLAUDE.md"), []byte("# manifest profile"), 0644); err != nil {
+		t.Fatalf("write manifest CLAUDE.md: %v", err)
+	}
+
+	e.mustRun("use", "manifested")
+
+	liveClaude := filepath.Join(e.home, ".claude", "CLAUDE.md")
+	data, err := os.ReadFile(liveClaude)
+	if err != nil {
+		t.Fatalf("read live CLAUDE.md: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "# manifest profile" {
+		t.Fatalf("unexpected live CLAUDE.md: %q", strings.TrimSpace(string(data)))
+	}
+
+	if err := os.WriteFile(liveClaude, []byte("# saved update"), 0644); err != nil {
+		t.Fatalf("overwrite live CLAUDE.md: %v", err)
+	}
+	e.mustRun("global", "save")
+
+	if _, err := os.Stat(filepath.Join(profileRoot, "cvm.profile.toml")); err != nil {
+		t.Fatalf("manifest should be preserved after save: %v", err)
+	}
+	data, err = os.ReadFile(filepath.Join(profileRoot, "claude", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read saved profile CLAUDE.md: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "# saved update" {
+		t.Fatalf("unexpected saved CLAUDE.md: %q", strings.TrimSpace(string(data)))
+	}
+}
+
 func TestProfileInspect(t *testing.T) {
 	e := newTestEnv(t)
 	e.seedGlobalClaude("# vanilla")

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -288,6 +288,40 @@ func TestUseSupportsManifestBackedClaudeProfile(t *testing.T) {
 	}
 }
 
+func TestManifestBackedProfileOverridesRestoreFromAssetDir(t *testing.T) {
+	e := newTestEnv(t)
+	e.seedGlobalClaude("# vanilla")
+
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "manifested")
+	writeTestFile(t, filepath.Join(profileRoot, "cvm.profile.toml"), "name = \"manifested\"\nharnesses = [\"claude\"]\n\n[assets]\nclaude = \"claude\"\n")
+	writeTestFile(t, filepath.Join(profileRoot, "claude", "skills", "deploy", "SKILL.md"), "base skill")
+
+	e.mustRun("use", "manifested")
+
+	liveSkill := filepath.Join(e.home, ".claude", "skills", "deploy", "SKILL.md")
+	overrideSkill := filepath.Join(e.home, ".cvm", "global", "overrides", "manifested", "skills", "deploy", "SKILL.md")
+	writeTestFile(t, overrideSkill, "override skill")
+	e.mustRun("override", "apply")
+
+	data, err := os.ReadFile(liveSkill)
+	if err != nil {
+		t.Fatalf("read live skill after apply: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "override skill" {
+		t.Fatalf("unexpected live override content: %q", strings.TrimSpace(string(data)))
+	}
+
+	e.mustRun("global", "save")
+
+	data, err = os.ReadFile(filepath.Join(profileRoot, "claude", "skills", "deploy", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read base skill after save: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "base skill" {
+		t.Fatalf("base skill should have been restored from manifest asset dir before save, got %q", strings.TrimSpace(string(data)))
+	}
+}
+
 func TestProfileInspect(t *testing.T) {
 	e := newTestEnv(t)
 	e.seedGlobalClaude("# vanilla")
@@ -845,5 +879,15 @@ func assertJSONKeyExists(t *testing.T, path, want string) {
 	}
 	if _, ok := cfg[want]; !ok {
 		t.Fatalf("json %s missing key %q", path, want)
+	}
+}
+
+func writeTestFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,62 +17,10 @@ const (
 	ClaudeDirName = ".claude"
 )
 
-// ManagedClaudeDirItems are the config files/dirs that cvm manages inside
-// ~/.claude/ or .claude/. Additional MCP config files live outside those
-// directories and are handled per-scope.
-// Everything else (sessions/, cache/, history.jsonl, etc.) is runtime and never touched.
-var ManagedClaudeDirItems = []string{
-	"CLAUDE.md",
-	"settings.json",
-	"settings.local.json",
-	"keybindings.json",
-	"statusline-command.sh",
-	"commands",
-	"skills",
-	"agents",
-	"hooks",
-	"rules",
-	"output-styles",
-	"teams",
-}
-
-func ManagedProfileItems(scope Scope) []string {
-	items := append([]string{}, ManagedClaudeDirItems...)
-	if scope == ScopeGlobal {
-		items = append(items, ".claude.json")
-	} else {
-		items = append(items, ".mcp.json")
-	}
-	return items
-}
-
-func ProfileDiscoveryItems() []string {
-	items := append([]string{}, ManagedClaudeDirItems...)
-	items = append(items, ".claude.json", ".mcp.json")
-	return items
-}
-
 // CvmHome returns ~/.cvm
 func CvmHome() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, CvmDirName)
-}
-
-// ClaudeHome returns ~/.claude
-func ClaudeHome() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ClaudeDirName)
-}
-
-// ClaudeUserConfigPath returns ~/.claude.json
-func ClaudeUserConfigPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".claude.json")
-}
-
-// ProjectMCPConfigPath returns <projectPath>/.mcp.json
-func ProjectMCPConfigPath(projectPath string) string {
-	return filepath.Join(projectPath, ".mcp.json")
 }
 
 // GlobalProfilesDir returns ~/.cvm/global/profiles
@@ -116,11 +64,6 @@ func OverrideDir(scope Scope, name string, projectPath string) string {
 // StatePath returns ~/.cvm/state.json
 func StatePath() string {
 	return filepath.Join(CvmHome(), "state.json")
-}
-
-// ProjectClaudeDir returns <projectPath>/.claude
-func ProjectClaudeDir(projectPath string) string {
-	return filepath.Join(projectPath, ClaudeDirName)
 }
 
 // hashPath creates a filesystem-safe hash of a path for per-project storage

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -1,0 +1,71 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/chichex/cvm/internal/config"
+)
+
+type claudeHarness struct{}
+
+var managedClaudeDirItems = []string{
+	"CLAUDE.md",
+	"settings.json",
+	"settings.local.json",
+	"keybindings.json",
+	"statusline-command.sh",
+	"commands",
+	"skills",
+	"agents",
+	"hooks",
+	"rules",
+	"output-styles",
+	"teams",
+}
+
+func Claude() Harness {
+	return claudeHarness{}
+}
+
+func (claudeHarness) Name() string {
+	return "claude"
+}
+
+func (claudeHarness) TargetDir(scope config.Scope, projectPath string) string {
+	if scope == config.ScopeGlobal {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".claude")
+	}
+	return filepath.Join(projectPath, ".claude")
+}
+
+func (claudeHarness) ManagedDirItems() []string {
+	return append([]string{}, managedClaudeDirItems...)
+}
+
+func (claudeHarness) ExternalManagedPath(scope config.Scope, projectPath string) (ManagedPath, bool) {
+	home, _ := os.UserHomeDir()
+	switch scope {
+	case config.ScopeGlobal:
+		return ManagedPath{
+			ProfilePath: ".claude.json",
+			LivePath:    filepath.Join(home, ".claude.json"),
+		}, true
+	case config.ScopeLocal:
+		return ManagedPath{
+			ProfilePath: ".mcp.json",
+			LivePath:    filepath.Join(projectPath, ".mcp.json"),
+		}, true
+	default:
+		return ManagedPath{}, false
+	}
+}
+
+func (h claudeHarness) ProfileDiscoveryItems() []string {
+	return ManagedProfileItems(h, config.ScopeGlobal, "")
+}
+
+func (claudeHarness) InstructionsFile() string {
+	return "CLAUDE.md"
+}

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -63,9 +63,19 @@ func (claudeHarness) ExternalManagedPath(scope config.Scope, projectPath string)
 }
 
 func (h claudeHarness) ProfileDiscoveryItems() []string {
-	return ManagedProfileItems(h, config.ScopeGlobal, "")
+	items := append([]string{}, h.ManagedDirItems()...)
+	items = append(items, ".claude.json", ".mcp.json")
+	return items
 }
 
-func (claudeHarness) InstructionsFile() string {
+func (claudeHarness) MarkdownInstructionsFile() string {
 	return "CLAUDE.md"
+}
+
+func (claudeHarness) IsUserMCPPath(profilePath string) bool {
+	return profilePath == ".claude.json"
+}
+
+func (claudeHarness) IsMCPPath(profilePath string) bool {
+	return profilePath == ".claude.json" || profilePath == ".mcp.json"
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -1,0 +1,34 @@
+package harness
+
+import "github.com/chichex/cvm/internal/config"
+
+type ManagedPath struct {
+	ProfilePath string
+	LivePath    string
+}
+
+type Harness interface {
+	Name() string
+	TargetDir(scope config.Scope, projectPath string) string
+	ManagedDirItems() []string
+	ExternalManagedPath(scope config.Scope, projectPath string) (ManagedPath, bool)
+	ProfileDiscoveryItems() []string
+	InstructionsFile() string
+}
+
+func ManagedProfileItems(h Harness, scope config.Scope, projectPath string) []string {
+	items := append([]string{}, h.ManagedDirItems()...)
+	if extra, ok := h.ExternalManagedPath(scope, projectPath); ok {
+		items = append(items, extra.ProfilePath)
+	}
+	return items
+}
+
+func ByName(name string) (Harness, bool) {
+	switch name {
+	case "claude":
+		return Claude(), true
+	default:
+		return nil, false
+	}
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -13,7 +13,9 @@ type Harness interface {
 	ManagedDirItems() []string
 	ExternalManagedPath(scope config.Scope, projectPath string) (ManagedPath, bool)
 	ProfileDiscoveryItems() []string
-	InstructionsFile() string
+	MarkdownInstructionsFile() string
+	IsUserMCPPath(profilePath string) bool
+	IsMCPPath(profilePath string) bool
 }
 
 func ManagedProfileItems(h Harness, scope config.Scope, projectPath string) []string {

--- a/internal/profile/manifest.go
+++ b/internal/profile/manifest.go
@@ -13,6 +13,8 @@ import (
 
 const manifestFileName = "cvm.profile.toml"
 
+// LoadManifest intentionally supports only the small manifest subset cvm owns
+// today. Replace this with a real TOML parser before expanding the schema.
 type Manifest struct {
 	Name      string
 	Harnesses []string
@@ -35,6 +37,7 @@ func LoadManifest(profileDir string) (*Manifest, error) {
 	}
 
 	section := ""
+	parsedHarnesses := false
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	for scanner.Scan() {
 		line := strings.TrimSpace(stripComment(scanner.Text()))
@@ -67,9 +70,11 @@ func LoadManifest(profileDir string) (*Manifest, error) {
 				if err != nil {
 					return nil, fmt.Errorf("parsing harnesses: %w", err)
 				}
-				if len(parsed) > 0 {
-					manifest.Harnesses = parsed
+				parsedHarnesses = true
+				if len(parsed) == 0 {
+					return nil, fmt.Errorf("harnesses must not be empty")
 				}
+				manifest.Harnesses = parsed
 			}
 		case "assets":
 			parsed, err := parseStringValue(value)
@@ -83,7 +88,7 @@ func LoadManifest(profileDir string) (*Manifest, error) {
 		return nil, err
 	}
 
-	if len(manifest.Harnesses) == 0 {
+	if !parsedHarnesses && len(manifest.Harnesses) == 0 {
 		manifest.Harnesses = []string{"claude"}
 	}
 	return manifest, nil
@@ -140,6 +145,7 @@ func LooksLikeProfileDir(profileDir string) bool {
 				}
 			}
 		}
+		return false
 	}
 
 	claude := harness.Claude()

--- a/internal/profile/manifest.go
+++ b/internal/profile/manifest.go
@@ -1,0 +1,197 @@
+package profile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/chichex/cvm/internal/harness"
+)
+
+const manifestFileName = "cvm.profile.toml"
+
+type Manifest struct {
+	Name      string
+	Harnesses []string
+	Assets    map[string]string
+}
+
+func LoadManifest(profileDir string) (*Manifest, error) {
+	manifest := &Manifest{
+		Name:      filepath.Base(profileDir),
+		Harnesses: []string{"claude"},
+		Assets:    map[string]string{},
+	}
+
+	data, err := os.ReadFile(filepath.Join(profileDir, manifestFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return manifest, nil
+		}
+		return nil, err
+	}
+
+	section := ""
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(stripComment(scanner.Text()))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(line[1 : len(line)-1])
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid manifest line %q", line)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		switch section {
+		case "":
+			switch key {
+			case "name":
+				parsed, err := parseStringValue(value)
+				if err != nil {
+					return nil, fmt.Errorf("parsing name: %w", err)
+				}
+				manifest.Name = parsed
+			case "harnesses":
+				parsed, err := parseStringListValue(value)
+				if err != nil {
+					return nil, fmt.Errorf("parsing harnesses: %w", err)
+				}
+				if len(parsed) > 0 {
+					manifest.Harnesses = parsed
+				}
+			}
+		case "assets":
+			parsed, err := parseStringValue(value)
+			if err != nil {
+				return nil, fmt.Errorf("parsing asset %q: %w", key, err)
+			}
+			manifest.Assets[key] = parsed
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(manifest.Harnesses) == 0 {
+		manifest.Harnesses = []string{"claude"}
+	}
+	return manifest, nil
+}
+
+func (m *Manifest) SupportsHarness(name string) bool {
+	for _, harnessName := range m.Harnesses {
+		if harnessName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manifest) AssetDir(profileDir string, h harness.Harness) (string, error) {
+	raw := strings.TrimSpace(m.Assets[h.Name()])
+	if raw == "" || raw == "." {
+		return profileDir, nil
+	}
+
+	clean := filepath.Clean(raw)
+	if filepath.IsAbs(clean) {
+		return "", fmt.Errorf("asset dir %q must be relative", raw)
+	}
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("asset dir %q escapes the profile root", raw)
+	}
+	return filepath.Join(profileDir, clean), nil
+}
+
+func HasManifest(profileDir string) bool {
+	_, err := os.Stat(filepath.Join(profileDir, manifestFileName))
+	return err == nil
+}
+
+func LooksLikeProfileDir(profileDir string) bool {
+	if HasManifest(profileDir) {
+		manifest, err := LoadManifest(profileDir)
+		if err != nil {
+			return false
+		}
+		for _, harnessName := range manifest.Harnesses {
+			h, ok := harness.ByName(harnessName)
+			if !ok {
+				continue
+			}
+			assetDir, err := manifest.AssetDir(profileDir, h)
+			if err != nil {
+				return false
+			}
+			for _, item := range h.ProfileDiscoveryItems() {
+				if _, err := os.Stat(filepath.Join(assetDir, item)); err == nil {
+					return true
+				}
+			}
+		}
+	}
+
+	claude := harness.Claude()
+	for _, item := range claude.ProfileDiscoveryItems() {
+		if _, err := os.Stat(filepath.Join(profileDir, item)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func stripComment(line string) string {
+	inString := false
+	for i, r := range line {
+		switch r {
+		case '"':
+			inString = !inString
+		case '#':
+			if !inString {
+				return line[:i]
+			}
+		}
+	}
+	return line
+}
+
+func parseStringValue(value string) (string, error) {
+	parsed, err := strconv.Unquote(value)
+	if err != nil {
+		return "", fmt.Errorf("expected quoted string, got %q", value)
+	}
+	return parsed, nil
+}
+
+func parseStringListValue(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		return nil, fmt.Errorf("expected array, got %q", value)
+	}
+	body := strings.TrimSpace(value[1 : len(value)-1])
+	if body == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(body, ",")
+	items := make([]string, 0, len(parts))
+	for _, part := range parts {
+		parsed, err := parseStringValue(strings.TrimSpace(part))
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, parsed)
+	}
+	return items, nil
+}

--- a/internal/profile/manifest_test.go
+++ b/internal/profile/manifest_test.go
@@ -1,0 +1,70 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chichex/cvm/internal/harness"
+)
+
+func TestLoadManifestDefaultsToClaudeRoot(t *testing.T) {
+	dir := t.TempDir()
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if !manifest.SupportsHarness("claude") {
+		t.Fatal("default manifest should support claude")
+	}
+
+	assetDir, err := manifest.AssetDir(dir, harness.Claude())
+	if err != nil {
+		t.Fatalf("AssetDir: %v", err)
+	}
+	if assetDir != dir {
+		t.Fatalf("unexpected asset dir: got %q want %q", assetDir, dir)
+	}
+}
+
+func TestLoadManifestSupportsHarnessSpecificAssetDir(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("name = \"lite\"\nharnesses = [\"claude\", \"codex\"]\n\n[assets]\nclaude = \"claude\"\ncodex = \"codex\"\n")
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), body, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if !manifest.SupportsHarness("codex") {
+		t.Fatal("manifest should support codex")
+	}
+
+	assetDir, err := manifest.AssetDir(dir, harness.Claude())
+	if err != nil {
+		t.Fatalf("AssetDir: %v", err)
+	}
+	want := filepath.Join(dir, "claude")
+	if assetDir != want {
+		t.Fatalf("unexpected asset dir: got %q want %q", assetDir, want)
+	}
+}
+
+func TestManifestRejectsEscapingAssetDir(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("harnesses = [\"claude\"]\n\n[assets]\nclaude = \"../escape\"\n")
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), body, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if _, err := manifest.AssetDir(dir, harness.Claude()); err == nil {
+		t.Fatal("expected AssetDir to reject escaping path")
+	}
+}

--- a/internal/profile/manifest_test.go
+++ b/internal/profile/manifest_test.go
@@ -68,3 +68,45 @@ func TestManifestRejectsEscapingAssetDir(t *testing.T) {
 		t.Fatal("expected AssetDir to reject escaping path")
 	}
 }
+
+func TestManifestRejectsExplicitEmptyHarnesses(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("harnesses = []\n")
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), body, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if _, err := LoadManifest(dir); err == nil {
+		t.Fatal("expected empty harness list to fail")
+	}
+}
+
+func TestLooksLikeProfileDirRejectsInvalidManifest(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("harnesses = [\n")
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), body, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("legacy fallback"), 0644); err != nil {
+		t.Fatalf("write legacy CLAUDE.md: %v", err)
+	}
+
+	if LooksLikeProfileDir(dir) {
+		t.Fatal("manifest-backed profiles should not fall back to legacy discovery when manifest is invalid")
+	}
+}
+
+func TestLooksLikeProfileDirDoesNotFallBackWhenManifestDeclaresAssetDir(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("harnesses = [\"claude\"]\n\n[assets]\nclaude = \"claude\"\n")
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), body, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("legacy fallback"), 0644); err != nil {
+		t.Fatalf("write legacy CLAUDE.md: %v", err)
+	}
+
+	if LooksLikeProfileDir(dir) {
+		t.Fatal("manifest-backed profiles should only discover assets from manifest-declared locations")
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -377,7 +377,7 @@ type managedPath struct {
 
 func CleanManagedItems(h harness.Harness, scope config.Scope, liveDir, projectPath string) error {
 	for _, item := range managedPaths(h, scope, liveDir, projectPath) {
-		if isClaudeUserMCPPath(item.ProfilePath) {
+		if h.IsUserMCPPath(item.ProfilePath) {
 			if err := removeUserMCPServers(item.LivePath); err != nil {
 				return err
 			}
@@ -393,7 +393,7 @@ func CleanManagedItems(h harness.Harness, scope config.Scope, liveDir, projectPa
 func CopyManagedItems(h harness.Harness, scope config.Scope, srcProfileDir, dstLiveDir, projectPath string) error {
 	for _, item := range managedPaths(h, scope, dstLiveDir, projectPath) {
 		srcPath := filepath.Join(srcProfileDir, item.ProfilePath)
-		if isClaudeUserMCPPath(item.ProfilePath) {
+		if h.IsUserMCPPath(item.ProfilePath) {
 			if err := applyUserMCPServers(srcPath, item.LivePath); err != nil {
 				return err
 			}
@@ -424,7 +424,7 @@ func CopyManagedItems(h harness.Harness, scope config.Scope, srcProfileDir, dstL
 func captureManagedItems(h harness.Harness, scope config.Scope, srcLiveDir, dstProfileDir, projectPath string) error {
 	for _, item := range managedPaths(h, scope, srcLiveDir, projectPath) {
 		srcPath := item.LivePath
-		if isClaudeUserMCPPath(item.ProfilePath) {
+		if h.IsUserMCPPath(item.ProfilePath) {
 			if err := captureUserMCPServers(srcPath, filepath.Join(dstProfileDir, item.ProfilePath)); err != nil {
 				return err
 			}
@@ -633,14 +633,14 @@ func ApplyOverrides(h harness.Harness, scope config.Scope, name string, liveDir 
 				return fmt.Errorf("merging override dir %s: %w", item.ProfilePath, err)
 			}
 
-		// CLAUDE.md: append override content
-		case item.ProfilePath == h.InstructionsFile():
+		// Markdown instructions files are additive so user guidance layers on top.
+		case item.ProfilePath == h.MarkdownInstructionsFile():
 			if err := appendFile(overSrc, item.LivePath); err != nil {
-				return fmt.Errorf("appending override %s: %w", h.InstructionsFile(), err)
+				return fmt.Errorf("appending override %s: %w", h.MarkdownInstructionsFile(), err)
 			}
 
 		// MCP config: sub-key merge for mcpServers (additive), top-level for others
-		case isClaudeMCPProfilePath(item.ProfilePath):
+		case h.IsMCPPath(item.ProfilePath):
 			override, err := readJSONFile(overSrc)
 			if err != nil {
 				return fmt.Errorf("reading override %s: %w", item.ProfilePath, err)
@@ -791,6 +791,10 @@ func StripOverrides(h harness.Harness, scope config.Scope, name string, liveDir 
 	}
 
 	profileDir := ProfileDir(scope, name)
+	baseProfileDir, err := profileAssetDir(profileDir, h)
+	if err != nil {
+		return err
+	}
 
 	for _, item := range managedPaths(h, scope, liveDir, projectPath) {
 		overSrc := filepath.Join(overDir, item.ProfilePath)
@@ -811,7 +815,7 @@ func StripOverrides(h harness.Harness, scope config.Scope, name string, liveDir 
 					return err
 				}
 				// Restore from base profile if this file existed there too
-				basePath := filepath.Join(profileDir, item.ProfilePath, rel)
+				basePath := filepath.Join(baseProfileDir, item.ProfilePath, rel)
 				if _, err := os.Stat(basePath); err == nil {
 					if err := CopyFile(basePath, target); err != nil {
 						return err
@@ -831,8 +835,8 @@ func StripOverrides(h harness.Harness, scope config.Scope, name string, liveDir 
 				return fmt.Errorf("stripping override dir %s: %w", item.ProfilePath, err)
 			}
 
-		// CLAUDE.md: truncate at the override separator
-		case item.ProfilePath == h.InstructionsFile():
+		// Markdown instructions files are additive; strip back to the base content.
+		case item.ProfilePath == h.MarkdownInstructionsFile():
 			data, err := os.ReadFile(item.LivePath)
 			if err != nil {
 				continue
@@ -840,12 +844,12 @@ func StripOverrides(h harness.Harness, scope config.Scope, name string, liveDir 
 			separator := "\n\n# --- User Overrides ---\n\n"
 			if idx := strings.Index(string(data), separator); idx >= 0 {
 				if err := os.WriteFile(item.LivePath, data[:idx], 0644); err != nil {
-					return fmt.Errorf("stripping override from %s: %w", h.InstructionsFile(), err)
+					return fmt.Errorf("stripping override from %s: %w", h.MarkdownInstructionsFile(), err)
 				}
 			}
 
 		// MCP config: strip at sub-key level for mcpServers, top-level for others
-		case isClaudeMCPProfilePath(item.ProfilePath):
+		case h.IsMCPPath(item.ProfilePath):
 			override, err := readJSONFile(overSrc)
 			if err != nil {
 				continue
@@ -854,7 +858,7 @@ func StripOverrides(h harness.Harness, scope config.Scope, name string, liveDir 
 			if err != nil {
 				continue
 			}
-			baseSrc := filepath.Join(profileDir, item.ProfilePath)
+			baseSrc := filepath.Join(baseProfileDir, item.ProfilePath)
 			base, _ := readJSONFile(baseSrc)
 			if base == nil {
 				base = map[string]any{}
@@ -902,7 +906,7 @@ func StripOverrides(h harness.Harness, scope config.Scope, name string, liveDir 
 
 		// Other files (JSON, scripts, etc.): restore from base profile
 		default:
-			baseSrc := filepath.Join(profileDir, item.ProfilePath)
+			baseSrc := filepath.Join(baseProfileDir, item.ProfilePath)
 			if baseInfo, err := os.Stat(baseSrc); err == nil {
 				if baseInfo.IsDir() {
 					if err := os.RemoveAll(item.LivePath); err != nil {
@@ -987,12 +991,4 @@ func clearDirContents(dir string) error {
 		}
 	}
 	return nil
-}
-
-func isClaudeUserMCPPath(profilePath string) bool {
-	return profilePath == ".claude.json"
-}
-
-func isClaudeMCPProfilePath(profilePath string) bool {
-	return profilePath == ".claude.json" || profilePath == ".mcp.json"
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/chichex/cvm/internal/config"
+	"github.com/chichex/cvm/internal/harness"
 	"github.com/chichex/cvm/internal/state"
 )
 
@@ -37,10 +38,7 @@ func profilesDir(scope config.Scope) string {
 }
 
 func targetDir(scope config.Scope, projectPath string) string {
-	if scope == config.ScopeGlobal {
-		return config.ClaudeHome()
-	}
-	return config.ProjectClaudeDir(projectPath)
+	return defaultHarness().TargetDir(scope, projectPath)
 }
 
 func ProfileDir(scope config.Scope, name string) string {
@@ -65,7 +63,7 @@ func Init(scope config.Scope, name string, from string, projectPath string) erro
 		}
 	} else {
 		tgt := targetDir(scope, projectPath)
-		if err := captureManagedItems(scope, tgt, dir, projectPath); err != nil {
+		if err := captureManagedItems(defaultHarness(), scope, tgt, dir, projectPath); err != nil {
 			return fmt.Errorf("copying managed items: %w", err)
 		}
 	}
@@ -73,8 +71,13 @@ func Init(scope config.Scope, name string, from string, projectPath string) erro
 }
 
 func Use(scope config.Scope, name string, projectPath string) error {
-	dir := ProfileDir(scope, name)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
+	h := defaultHarness()
+	profileDir := ProfileDir(scope, name)
+	dir, err := profileAssetDir(profileDir, h)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(profileDir); os.IsNotExist(err) {
 		return fmt.Errorf("profile %q not found", name)
 	}
 
@@ -103,16 +106,16 @@ func Use(scope config.Scope, name string, projectPath string) error {
 
 	// Clean and apply
 	tgt := targetDir(scope, projectPath)
-	if err := CleanManagedItems(scope, tgt, projectPath); err != nil {
+	if err := CleanManagedItems(h, scope, tgt, projectPath); err != nil {
 		return fmt.Errorf("cleaning target: %w", err)
 	}
 	if err := os.MkdirAll(tgt, 0755); err != nil {
 		return err
 	}
-	if err := CopyManagedItems(scope, dir, tgt, projectPath); err != nil {
+	if err := CopyManagedItems(h, scope, dir, tgt, projectPath); err != nil {
 		return fmt.Errorf("applying profile: %w", err)
 	}
-	if err := ApplyOverrides(scope, name, tgt, projectPath); err != nil {
+	if err := ApplyOverrides(h, scope, name, tgt, projectPath); err != nil {
 		return fmt.Errorf("applying overrides: %w", err)
 	}
 
@@ -126,6 +129,7 @@ func Use(scope config.Scope, name string, projectPath string) error {
 }
 
 func UseNone(scope config.Scope, projectPath string) error {
+	h := defaultHarness()
 	st, err := state.Load()
 	if err != nil {
 		return err
@@ -144,7 +148,7 @@ func UseNone(scope config.Scope, projectPath string) error {
 	}
 
 	tgt := targetDir(scope, projectPath)
-	if err := CleanManagedItems(scope, tgt, projectPath); err != nil {
+	if err := CleanManagedItems(h, scope, tgt, projectPath); err != nil {
 		return fmt.Errorf("cleaning target: %w", err)
 	}
 	if err := RestoreVanilla(scope, projectPath); err != nil {
@@ -181,12 +185,17 @@ func List(scope config.Scope, projectPath string) ([]ProfileInfo, error) {
 		active = st.GetLocal(projectPath)
 	}
 
+	h := defaultHarness()
 	var profiles []ProfileInfo
 	for _, e := range entries {
 		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
-		items := countItems(scope, filepath.Join(dir, e.Name()))
+		assetDir, err := profileAssetDir(filepath.Join(dir, e.Name()), h)
+		if err != nil {
+			return nil, err
+		}
+		items := countItems(h, scope, assetDir, projectPath)
 		profiles = append(profiles, ProfileInfo{
 			Name:   e.Name(),
 			Active: e.Name() == active,
@@ -208,7 +217,12 @@ func Current(scope config.Scope, projectPath string) (string, error) {
 }
 
 func Inspect(scope config.Scope, name, projectPath string) (*Inventory, error) {
-	dir := ProfileDir(scope, name)
+	h := defaultHarness()
+	profileDir := ProfileDir(scope, name)
+	dir, err := profileAssetDir(profileDir, h)
+	if err != nil {
+		return nil, err
+	}
 	info := &Inventory{
 		Name:  name,
 		Scope: scope,
@@ -244,17 +258,15 @@ func Inspect(scope config.Scope, name, projectPath string) (*Inventory, error) {
 	sort.Strings(info.Files)
 
 	// Extract MCP server names from the config file
-	mcpFile := ".claude.json"
-	if scope == config.ScopeLocal {
-		mcpFile = ".mcp.json"
-	}
-	mcpPath := filepath.Join(dir, mcpFile)
-	if cfg, err := readJSONFile(mcpPath); err == nil {
-		if servers, ok := cfg["mcpServers"].(map[string]any); ok {
-			for name := range servers {
-				info.MCPServers = append(info.MCPServers, name)
+	if extra, ok := h.ExternalManagedPath(scope, projectPath); ok {
+		mcpPath := filepath.Join(dir, extra.ProfilePath)
+		if cfg, err := readJSONFile(mcpPath); err == nil {
+			if servers, ok := cfg["mcpServers"].(map[string]any); ok {
+				for name := range servers {
+					info.MCPServers = append(info.MCPServers, name)
+				}
+				sort.Strings(info.MCPServers)
 			}
-			sort.Strings(info.MCPServers)
 		}
 	}
 
@@ -262,27 +274,26 @@ func Inspect(scope config.Scope, name, projectPath string) (*Inventory, error) {
 }
 
 func Save(scope config.Scope, name string, projectPath string) error {
-	dir := ProfileDir(scope, name)
+	h := defaultHarness()
+	profileDir := ProfileDir(scope, name)
+	dir, err := profileAssetDir(profileDir, h)
+	if err != nil {
+		return err
+	}
 	tgt := targetDir(scope, projectPath)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
+	if _, err := os.Stat(profileDir); os.IsNotExist(err) {
 		return fmt.Errorf("profile %q not found", name)
 	}
 	// Strip overrides from live dir before capturing to prevent
 	// baking them into the base profile
-	if err := StripOverrides(scope, name, tgt, projectPath); err != nil {
+	if err := StripOverrides(h, scope, name, tgt, projectPath); err != nil {
 		return fmt.Errorf("stripping overrides before save: %w", err)
 	}
 	// Always re-apply overrides to live dir, even if capture fails
-	defer ApplyOverrides(scope, name, tgt, projectPath) //nolint:errcheck
+	defer ApplyOverrides(h, scope, name, tgt, projectPath) //nolint:errcheck
 
-	entries, err := os.ReadDir(dir)
-	if err != nil {
+	if err := clearDirContents(dir); err != nil {
 		return err
-	}
-	for _, e := range entries {
-		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
-			return err
-		}
 	}
 	if _, err := os.Stat(tgt); err != nil {
 		if os.IsNotExist(err) {
@@ -290,7 +301,7 @@ func Save(scope config.Scope, name string, projectPath string) error {
 		}
 		return err
 	}
-	return captureManagedItems(scope, tgt, dir, projectPath)
+	return captureManagedItems(h, scope, tgt, dir, projectPath)
 }
 
 func Remove(scope config.Scope, name string, projectPath string) error {
@@ -332,7 +343,7 @@ func EnsureVanilla(scope config.Scope, projectPath string) error {
 		return err
 	}
 	src := targetDir(scope, projectPath)
-	return captureManagedItems(scope, src, vdir, projectPath)
+	return captureManagedItems(defaultHarness(), scope, src, vdir, projectPath)
 }
 
 func RestoreVanilla(scope config.Scope, projectPath string) error {
@@ -344,7 +355,7 @@ func RestoreVanilla(scope config.Scope, projectPath string) error {
 	if err := os.MkdirAll(dst, 0755); err != nil {
 		return err
 	}
-	return CopyManagedItems(scope, vdir, dst, projectPath)
+	return CopyManagedItems(defaultHarness(), scope, vdir, dst, projectPath)
 }
 
 func HasVanilla(scope config.Scope, projectPath string) bool {
@@ -354,7 +365,7 @@ func HasVanilla(scope config.Scope, projectPath string) bool {
 
 func Nuke(scope config.Scope, projectPath string) error {
 	dst := targetDir(scope, projectPath)
-	return CleanManagedItems(scope, dst, projectPath)
+	return CleanManagedItems(defaultHarness(), scope, dst, projectPath)
 }
 
 // --- File operations ---
@@ -364,9 +375,9 @@ type managedPath struct {
 	LivePath    string
 }
 
-func CleanManagedItems(scope config.Scope, liveDir, projectPath string) error {
-	for _, item := range managedPaths(scope, liveDir, projectPath) {
-		if item.ProfilePath == ".claude.json" {
+func CleanManagedItems(h harness.Harness, scope config.Scope, liveDir, projectPath string) error {
+	for _, item := range managedPaths(h, scope, liveDir, projectPath) {
+		if isClaudeUserMCPPath(item.ProfilePath) {
 			if err := removeUserMCPServers(item.LivePath); err != nil {
 				return err
 			}
@@ -379,10 +390,10 @@ func CleanManagedItems(scope config.Scope, liveDir, projectPath string) error {
 	return nil
 }
 
-func CopyManagedItems(scope config.Scope, srcProfileDir, dstLiveDir, projectPath string) error {
-	for _, item := range managedPaths(scope, dstLiveDir, projectPath) {
+func CopyManagedItems(h harness.Harness, scope config.Scope, srcProfileDir, dstLiveDir, projectPath string) error {
+	for _, item := range managedPaths(h, scope, dstLiveDir, projectPath) {
 		srcPath := filepath.Join(srcProfileDir, item.ProfilePath)
-		if item.ProfilePath == ".claude.json" {
+		if isClaudeUserMCPPath(item.ProfilePath) {
 			if err := applyUserMCPServers(srcPath, item.LivePath); err != nil {
 				return err
 			}
@@ -410,10 +421,10 @@ func CopyManagedItems(scope config.Scope, srcProfileDir, dstLiveDir, projectPath
 	return nil
 }
 
-func captureManagedItems(scope config.Scope, srcLiveDir, dstProfileDir, projectPath string) error {
-	for _, item := range managedPaths(scope, srcLiveDir, projectPath) {
+func captureManagedItems(h harness.Harness, scope config.Scope, srcLiveDir, dstProfileDir, projectPath string) error {
+	for _, item := range managedPaths(h, scope, srcLiveDir, projectPath) {
 		srcPath := item.LivePath
-		if item.ProfilePath == ".claude.json" {
+		if isClaudeUserMCPPath(item.ProfilePath) {
 			if err := captureUserMCPServers(srcPath, filepath.Join(dstProfileDir, item.ProfilePath)); err != nil {
 				return err
 			}
@@ -441,9 +452,9 @@ func captureManagedItems(scope config.Scope, srcLiveDir, dstProfileDir, projectP
 	return nil
 }
 
-func countItems(scope config.Scope, dir string) int {
+func countItems(h harness.Harness, scope config.Scope, dir, projectPath string) int {
 	count := 0
-	for _, item := range config.ManagedProfileItems(scope) {
+	for _, item := range harness.ManagedProfileItems(h, scope, projectPath) {
 		if _, err := os.Stat(filepath.Join(dir, item)); err == nil {
 			count++
 		}
@@ -451,25 +462,19 @@ func countItems(scope config.Scope, dir string) int {
 	return count
 }
 
-func managedPaths(scope config.Scope, liveDir, projectPath string) []managedPath {
-	paths := make([]managedPath, 0, len(config.ManagedProfileItems(scope)))
-	for _, item := range config.ManagedClaudeDirItems {
+func managedPaths(h harness.Harness, scope config.Scope, liveDir, projectPath string) []managedPath {
+	paths := make([]managedPath, 0, len(harness.ManagedProfileItems(h, scope, projectPath)))
+	for _, item := range h.ManagedDirItems() {
 		paths = append(paths, managedPath{
 			ProfilePath: item,
 			LivePath:    filepath.Join(liveDir, item),
 		})
 	}
 
-	switch scope {
-	case config.ScopeGlobal:
+	if extra, ok := h.ExternalManagedPath(scope, projectPath); ok {
 		paths = append(paths, managedPath{
-			ProfilePath: ".claude.json",
-			LivePath:    config.ClaudeUserConfigPath(),
-		})
-	case config.ScopeLocal:
-		paths = append(paths, managedPath{
-			ProfilePath: ".mcp.json",
-			LivePath:    config.ProjectMCPConfigPath(projectPath),
+			ProfilePath: extra.ProfilePath,
+			LivePath:    extra.LivePath,
 		})
 	}
 
@@ -609,13 +614,13 @@ func OverrideDir(scope config.Scope, name string, projectPath string) string {
 
 // ApplyOverrides merges the user's override layer on top of the already-applied
 // profile in the live directory. This is called after CopyManagedItems.
-func ApplyOverrides(scope config.Scope, name string, liveDir string, projectPath string) error {
+func ApplyOverrides(h harness.Harness, scope config.Scope, name string, liveDir string, projectPath string) error {
 	overDir := OverrideDir(scope, name, projectPath)
 	if _, err := os.Stat(overDir); os.IsNotExist(err) {
 		return nil // no overrides — nothing to do
 	}
 
-	for _, item := range managedPaths(scope, liveDir, projectPath) {
+	for _, item := range managedPaths(h, scope, liveDir, projectPath) {
 		overSrc := filepath.Join(overDir, item.ProfilePath)
 		if _, err := os.Stat(overSrc); os.IsNotExist(err) {
 			continue
@@ -629,13 +634,13 @@ func ApplyOverrides(scope config.Scope, name string, liveDir string, projectPath
 			}
 
 		// CLAUDE.md: append override content
-		case item.ProfilePath == "CLAUDE.md":
+		case item.ProfilePath == h.InstructionsFile():
 			if err := appendFile(overSrc, item.LivePath); err != nil {
-				return fmt.Errorf("appending override CLAUDE.md: %w", err)
+				return fmt.Errorf("appending override %s: %w", h.InstructionsFile(), err)
 			}
 
 		// MCP config: sub-key merge for mcpServers (additive), top-level for others
-		case item.ProfilePath == ".claude.json" || item.ProfilePath == ".mcp.json":
+		case isClaudeMCPProfilePath(item.ProfilePath):
 			override, err := readJSONFile(overSrc)
 			if err != nil {
 				return fmt.Errorf("reading override %s: %w", item.ProfilePath, err)
@@ -779,7 +784,7 @@ func isJSONFile(name string) bool {
 // StripOverrides removes override contributions from the live directory so that
 // Save() captures only the base profile state. This prevents overrides from being
 // permanently baked into the base profile on profile switch.
-func StripOverrides(scope config.Scope, name string, liveDir string, projectPath string) error {
+func StripOverrides(h harness.Harness, scope config.Scope, name string, liveDir string, projectPath string) error {
 	overDir := OverrideDir(scope, name, projectPath)
 	if _, err := os.Stat(overDir); os.IsNotExist(err) {
 		return nil
@@ -787,7 +792,7 @@ func StripOverrides(scope config.Scope, name string, liveDir string, projectPath
 
 	profileDir := ProfileDir(scope, name)
 
-	for _, item := range managedPaths(scope, liveDir, projectPath) {
+	for _, item := range managedPaths(h, scope, liveDir, projectPath) {
 		overSrc := filepath.Join(overDir, item.ProfilePath)
 		if _, err := os.Stat(overSrc); os.IsNotExist(err) {
 			continue
@@ -827,7 +832,7 @@ func StripOverrides(scope config.Scope, name string, liveDir string, projectPath
 			}
 
 		// CLAUDE.md: truncate at the override separator
-		case item.ProfilePath == "CLAUDE.md":
+		case item.ProfilePath == h.InstructionsFile():
 			data, err := os.ReadFile(item.LivePath)
 			if err != nil {
 				continue
@@ -835,12 +840,12 @@ func StripOverrides(scope config.Scope, name string, liveDir string, projectPath
 			separator := "\n\n# --- User Overrides ---\n\n"
 			if idx := strings.Index(string(data), separator); idx >= 0 {
 				if err := os.WriteFile(item.LivePath, data[:idx], 0644); err != nil {
-					return fmt.Errorf("stripping override from CLAUDE.md: %w", err)
+					return fmt.Errorf("stripping override from %s: %w", h.InstructionsFile(), err)
 				}
 			}
 
 		// MCP config: strip at sub-key level for mcpServers, top-level for others
-		case item.ProfilePath == ".claude.json" || item.ProfilePath == ".mcp.json":
+		case isClaudeMCPProfilePath(item.ProfilePath):
 			override, err := readJSONFile(overSrc)
 			if err != nil {
 				continue
@@ -924,26 +929,70 @@ func StripOverrides(scope config.Scope, name string, liveDir string, projectPath
 // Reapply re-applies the active profile and its overrides to the live directory
 // without saving the current state first. Used by "cvm override apply".
 func Reapply(scope config.Scope, name string, projectPath string) error {
-	dir := ProfileDir(scope, name)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
+	h := defaultHarness()
+	profileDir := ProfileDir(scope, name)
+	dir, err := profileAssetDir(profileDir, h)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(profileDir); os.IsNotExist(err) {
 		return fmt.Errorf("profile %q not found", name)
 	}
 	tgt := targetDir(scope, projectPath)
 	// Strip current overrides to clean stale keys before fresh re-apply
-	if err := StripOverrides(scope, name, tgt, projectPath); err != nil {
+	if err := StripOverrides(h, scope, name, tgt, projectPath); err != nil {
 		return fmt.Errorf("stripping overrides: %w", err)
 	}
-	if err := CleanManagedItems(scope, tgt, projectPath); err != nil {
+	if err := CleanManagedItems(h, scope, tgt, projectPath); err != nil {
 		return fmt.Errorf("cleaning target: %w", err)
 	}
 	if err := os.MkdirAll(tgt, 0755); err != nil {
 		return err
 	}
-	if err := CopyManagedItems(scope, dir, tgt, projectPath); err != nil {
+	if err := CopyManagedItems(h, scope, dir, tgt, projectPath); err != nil {
 		return fmt.Errorf("applying profile: %w", err)
 	}
-	if err := ApplyOverrides(scope, name, tgt, projectPath); err != nil {
+	if err := ApplyOverrides(h, scope, name, tgt, projectPath); err != nil {
 		return fmt.Errorf("applying overrides: %w", err)
 	}
 	return nil
+}
+
+func defaultHarness() harness.Harness {
+	return harness.Claude()
+}
+
+func profileAssetDir(profileDir string, h harness.Harness) (string, error) {
+	manifest, err := LoadManifest(profileDir)
+	if err != nil {
+		return "", fmt.Errorf("loading manifest for profile %q: %w", filepath.Base(profileDir), err)
+	}
+	if !manifest.SupportsHarness(h.Name()) {
+		return "", fmt.Errorf("profile %q does not support harness %q", filepath.Base(profileDir), h.Name())
+	}
+	return manifest.AssetDir(profileDir, h)
+}
+
+func clearDirContents(dir string) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isClaudeUserMCPPath(profilePath string) bool {
+	return profilePath == ".claude.json"
+}
+
+func isClaudeMCPProfilePath(profilePath string) bool {
+	return profilePath == ".claude.json" || profilePath == ".mcp.json"
 }

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -29,14 +29,9 @@ func normalizeRepo(repo string) string {
 	return "https://github.com/" + repo
 }
 
-// looksLikeProfile checks if a directory contains Claude Code config files.
+// looksLikeProfile checks if a directory contains a cvm profile layout.
 func looksLikeProfile(dir string) bool {
-	for _, item := range config.ProfileDiscoveryItems() {
-		if _, err := os.Stat(filepath.Join(dir, item)); err == nil {
-			return true
-		}
-	}
-	return false
+	return profile.LooksLikeProfileDir(dir)
 }
 
 // discoverProfilePath tries to find a profile inside a cloned repo.
@@ -99,7 +94,7 @@ func discoverProfilePath(cacheDir, profileName string) (string, error) {
 		return "", errors.New(msg)
 	}
 
-	return "", fmt.Errorf("no profile found in repo. Make sure it contains CLAUDE.md, skills/, or other Claude Code config")
+	return "", fmt.Errorf("no profile found in repo. Make sure it contains cvm profile assets or a cvm.profile.toml manifest")
 }
 
 // Add registers a remote profile source and clones it.
@@ -146,7 +141,7 @@ func Add(profileName, repo, path, branch string, scope config.Scope, projectPath
 	}
 
 	if !looksLikeProfile(srcDir) {
-		return fmt.Errorf("path %q exists but doesn't look like a Claude Code profile (no CLAUDE.md, skills/, etc.)", path)
+		return fmt.Errorf("path %q exists but doesn't look like a cvm profile", path)
 	}
 
 	// Copy to profile

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -102,6 +102,17 @@ func TestPullByProfileUpdatesGlobalAndLocalMatches(t *testing.T) {
 	assertFileContent(t, filepath.Join(project, ".claude", "CLAUDE.md"), "new remote local")
 }
 
+func TestLooksLikeProfileWithManifestBackedClaudeAssets(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "cvm.profile.toml"), "name = \"work\"\nharnesses = [\"claude\"]\n\n[assets]\nclaude = \"claude\"\n")
+	writeFile(t, filepath.Join(root, "claude", "CLAUDE.md"), "hello")
+
+	if !looksLikeProfile(root) {
+		t.Fatal("expected manifest-backed profile layout to be detected")
+	}
+}
+
 func withFakeGit(t *testing.T) string {
 	t.Helper()
 

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/chichex/cvm/internal/config"
+	"github.com/chichex/cvm/internal/harness"
 	"github.com/chichex/cvm/internal/profile"
 	"github.com/chichex/cvm/internal/state"
 )
@@ -58,7 +59,7 @@ func TestPullByProfileUpdatesGlobalAndLocalMatches(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("PATH", withFakeGit(t))
 
-	writeFile(t, filepath.Join(config.ClaudeHome(), "CLAUDE.md"), "old global active")
+	writeFile(t, filepath.Join(harness.Claude().TargetDir(config.ScopeGlobal, ""), "CLAUDE.md"), "old global active")
 	writeFile(t, filepath.Join(project, ".claude", "CLAUDE.md"), "old local active")
 	writeFile(t, filepath.Join(profile.ProfileDir(config.ScopeGlobal, "work"), "CLAUDE.md"), "old global profile")
 	writeFile(t, filepath.Join(profile.ProfileDir(config.ScopeLocal, "work"), "CLAUDE.md"), "old local profile")
@@ -98,7 +99,7 @@ func TestPullByProfileUpdatesGlobalAndLocalMatches(t *testing.T) {
 		t.Fatalf("expected both remotes to update, got %v", updated)
 	}
 
-	assertFileContent(t, filepath.Join(config.ClaudeHome(), "CLAUDE.md"), "new remote global")
+	assertFileContent(t, filepath.Join(harness.Claude().TargetDir(config.ScopeGlobal, ""), "CLAUDE.md"), "new remote global")
 	assertFileContent(t, filepath.Join(project, ".claude", "CLAUDE.md"), "new remote local")
 }
 
@@ -110,6 +111,15 @@ func TestLooksLikeProfileWithManifestBackedClaudeAssets(t *testing.T) {
 
 	if !looksLikeProfile(root) {
 		t.Fatal("expected manifest-backed profile layout to be detected")
+	}
+}
+
+func TestLooksLikeProfileDetectsLocalMCPOnlyClaudeProfile(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".mcp.json"), `{"mcpServers":{"local":{}}}`)
+
+	if !looksLikeProfile(root) {
+		t.Fatal("expected .mcp.json-only Claude profile to be detected")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a first-class `internal/harness` layer with a Claude implementation
- add `cvm.profile.toml` parsing and manifest-backed asset directory resolution
- keep legacy Claude-root profiles working while allowing manifest-backed Claude profiles under `claude/`
- update profile application, save/reapply, remote discovery, and targeted tests around the new layout

## Why
This lands the architecture slice for #34 without mixing in multi-harness activation/state work from later issues. It gives `cvm` its own profile manifest and harness abstraction while preserving current Claude behavior.

## Testing
- `go test ./...`

## Related
- Closes #34
- Part of #31
