### PR TITLE
Add multi-harness state and CLI targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ When adding from a repo without a path, cvm auto-discovers the profile:
 ```bash
 cvm use work            # activate globally (~/.claude/)
 cvm use work --local    # activate for current project (.claude/)
+cvm use work --harness claude
 cvm use --none          # back to vanilla
 ```
 
@@ -92,11 +93,13 @@ cvm upgrade             # upgrade cvm itself to the latest version
 cvm nuke                # remove ALL managed config (global + local)
 cvm nuke --global       # only global
 cvm nuke --local        # only local project
+cvm nuke --harness claude
 cvm nuke -f             # skip confirmation
 
 cvm restore             # restore pre-cvm state from vanilla backup
 cvm restore --global    # only global
 cvm restore --local     # only local
+cvm restore --harness claude
 ```
 
 ### Remote management
@@ -109,7 +112,8 @@ cvm remote rm chiche   # unlink from remote (keeps local copy)
 ### Inspect
 
 ```bash
-cvm status             # show active profiles (global + local)
+cvm status             # show active profiles by harness (global + local)
+cvm status --harness claude
 cvm profile            # inspect active profile contents
 cvm profile show work  # inspect a specific stored profile
 ```

--- a/cmd/harness.go
+++ b/cmd/harness.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chichex/cvm/internal/harness"
+	"github.com/spf13/cobra"
+)
+
+const defaultHarnessName = "claude"
+
+func harnessFromFlag(cmd *cobra.Command) (harness.Harness, error) {
+	name, _ := cmd.Flags().GetString("harness")
+	if name == "" {
+		name = defaultHarnessName
+	}
+	h, ok := harness.ByName(name)
+	if !ok {
+		return nil, fmt.Errorf("unknown harness %q", name)
+	}
+	return h, nil
+}
+
+func selectedHarnesses(cmd *cobra.Command) ([]harness.Harness, error) {
+	name, _ := cmd.Flags().GetString("harness")
+	if name == "" {
+		return harness.All(), nil
+	}
+	h, ok := harness.ByName(name)
+	if !ok {
+		return nil, fmt.Errorf("unknown harness %q", name)
+	}
+	return []harness.Harness{h}, nil
+}

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -11,13 +11,17 @@ import (
 
 var nukeCmd = &cobra.Command{
 	Use:   "nuke",
-	Short: "Remove all managed config from Claude Code",
-	Long: `Removes all cvm-managed configuration files from ~/.claude/ and .claude/.
+	Short: "Remove managed config from harness targets",
+	Long: `Removes cvm-managed configuration files from harness target directories.
 Runtime files (sessions, cache, history) are never touched.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		globalOnly, _ := cmd.Flags().GetBool("global")
 		localOnly, _ := cmd.Flags().GetBool("local")
 		force, _ := cmd.Flags().GetBool("force")
+		harnesses, err := selectedHarnesses(cmd)
+		if err != nil {
+			return err
+		}
 
 		if !globalOnly && !localOnly {
 			globalOnly = true
@@ -40,11 +44,13 @@ Runtime files (sessions, cache, history) are never touched.`,
 		}
 
 		if globalOnly {
-			if err := profile.Nuke(config.ScopeGlobal, ""); err != nil {
-				return fmt.Errorf("nuking global: %w", err)
+			for _, h := range harnesses {
+				if err := profile.NukeWithHarness(config.ScopeGlobal, "", h); err != nil {
+					return fmt.Errorf("nuking global %s: %w", h.Name(), err)
+				}
+				st.ClearGlobalHarness(h.Name())
+				fmt.Printf("Nuked global config (%s harness: %s)\n", h.Name(), h.TargetDir(config.ScopeGlobal, ""))
 			}
-			st.SetGlobal("")
-			fmt.Println("Nuked global config (~/.claude/)")
 		}
 
 		if localOnly {
@@ -52,11 +58,13 @@ Runtime files (sessions, cache, history) are never touched.`,
 			if err != nil {
 				return err
 			}
-			if err := profile.Nuke(config.ScopeLocal, projectPath); err != nil {
-				return fmt.Errorf("nuking local: %w", err)
+			for _, h := range harnesses {
+				if err := profile.NukeWithHarness(config.ScopeLocal, projectPath, h); err != nil {
+					return fmt.Errorf("nuking local %s: %w", h.Name(), err)
+				}
+				st.ClearLocalHarness(projectPath, h.Name())
+				fmt.Printf("Nuked local config (%s harness: %s)\n", h.Name(), h.TargetDir(config.ScopeLocal, projectPath))
 			}
-			st.ClearLocal(projectPath)
-			fmt.Println("Nuked local config (.claude/)")
 		}
 
 		return st.Save()
@@ -67,4 +75,5 @@ func init() {
 	nukeCmd.Flags().Bool("global", false, "Only nuke global config")
 	nukeCmd.Flags().Bool("local", false, "Only nuke local config")
 	nukeCmd.Flags().BoolP("force", "f", false, "Skip confirmation")
+	nukeCmd.Flags().String("harness", "", "Only nuke one harness")
 }

--- a/cmd/override.go
+++ b/cmd/override.go
@@ -37,9 +37,9 @@ func overrideScope(cmd *cobra.Command) (config.Scope, string, string, error) {
 
 	var active string
 	if scope == config.ScopeGlobal {
-		active = st.Global.Active
+		active = st.GetGlobalHarness(defaultHarnessName)
 	} else {
-		active = st.GetLocal(projectPath)
+		active = st.GetLocalHarness(projectPath, defaultHarnessName)
 	}
 	if active == "" {
 		return "", "", "", fmt.Errorf("no active %s profile", scope)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -15,6 +15,10 @@ var restoreCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		globalOnly, _ := cmd.Flags().GetBool("global")
 		localOnly, _ := cmd.Flags().GetBool("local")
+		harnesses, err := selectedHarnesses(cmd)
+		if err != nil {
+			return err
+		}
 
 		if !globalOnly && !localOnly {
 			globalOnly = true
@@ -27,15 +31,19 @@ var restoreCmd = &cobra.Command{
 		}
 
 		if globalOnly {
-			if !profile.HasVanilla(config.ScopeGlobal, "") {
-				fmt.Println("No vanilla backup found for global config")
-			} else {
-				profile.Nuke(config.ScopeGlobal, "")
-				if err := profile.RestoreVanilla(config.ScopeGlobal, ""); err != nil {
-					return fmt.Errorf("restoring global: %w", err)
+			for _, h := range harnesses {
+				if !profile.HasVanillaWithHarness(config.ScopeGlobal, "", h) {
+					fmt.Printf("No vanilla backup found for global %s config\n", h.Name())
+				} else {
+					if err := profile.NukeWithHarness(config.ScopeGlobal, "", h); err != nil {
+						return fmt.Errorf("nuking global %s: %w", h.Name(), err)
+					}
+					if err := profile.RestoreVanillaWithHarness(config.ScopeGlobal, "", h); err != nil {
+						return fmt.Errorf("restoring global %s: %w", h.Name(), err)
+					}
+					st.ClearGlobalHarness(h.Name())
+					fmt.Printf("Restored global config to vanilla (%s harness)\n", h.Name())
 				}
-				st.SetGlobal("")
-				fmt.Println("Restored global config to vanilla")
 			}
 		}
 
@@ -44,15 +52,19 @@ var restoreCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			if !profile.HasVanilla(config.ScopeLocal, projectPath) {
-				fmt.Println("No vanilla backup found for local config")
-			} else {
-				profile.Nuke(config.ScopeLocal, projectPath)
-				if err := profile.RestoreVanilla(config.ScopeLocal, projectPath); err != nil {
-					return fmt.Errorf("restoring local: %w", err)
+			for _, h := range harnesses {
+				if !profile.HasVanillaWithHarness(config.ScopeLocal, projectPath, h) {
+					fmt.Printf("No vanilla backup found for local %s config\n", h.Name())
+				} else {
+					if err := profile.NukeWithHarness(config.ScopeLocal, projectPath, h); err != nil {
+						return fmt.Errorf("nuking local %s: %w", h.Name(), err)
+					}
+					if err := profile.RestoreVanillaWithHarness(config.ScopeLocal, projectPath, h); err != nil {
+						return fmt.Errorf("restoring local %s: %w", h.Name(), err)
+					}
+					st.ClearLocalHarness(projectPath, h.Name())
+					fmt.Printf("Restored local config to vanilla (%s harness)\n", h.Name())
 				}
-				st.ClearLocal(projectPath)
-				fmt.Println("Restored local config to vanilla")
 			}
 		}
 
@@ -63,4 +75,5 @@ var restoreCmd = &cobra.Command{
 func init() {
 	restoreCmd.Flags().Bool("global", false, "Only restore global")
 	restoreCmd.Flags().Bool("local", false, "Only restore local")
+	restoreCmd.Flags().String("harness", "", "Only restore one harness")
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,35 +5,43 @@ import (
 	"os"
 
 	"github.com/chichex/cvm/internal/config"
-	"github.com/chichex/cvm/internal/harness"
 	"github.com/chichex/cvm/internal/state"
 	"github.com/spf13/cobra"
 )
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Show active profiles (global + local)",
+	Short: "Show active profiles by harness (global + local)",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		st, err := state.Load()
 		if err != nil {
 			return err
 		}
-
-		// Global
-		globalProfile := st.Global.Active
-		if globalProfile == "" {
-			globalProfile = "(vanilla)"
+		harnesses, err := selectedHarnesses(cmd)
+		if err != nil {
+			return err
 		}
-		fmt.Printf("Global:  %-20s  → %s\n", globalProfile, harness.Claude().TargetDir(config.ScopeGlobal, ""))
 
-		// Local
 		cwd, _ := os.Getwd()
-		localProfile := st.GetLocal(cwd)
-		if localProfile == "" {
-			localProfile = "(vanilla)"
+		for _, h := range harnesses {
+			globalProfile := st.GetGlobalHarness(h.Name())
+			if globalProfile == "" {
+				globalProfile = "(vanilla)"
+			}
+			localProfile := st.GetLocalHarness(cwd, h.Name())
+			if localProfile == "" {
+				localProfile = "(vanilla)"
+			}
+
+			fmt.Printf("%s harness:\n", h.Name())
+			fmt.Printf("  Global: %-20s  -> %s\n", globalProfile, h.TargetDir(config.ScopeGlobal, ""))
+			fmt.Printf("  Local:  %-20s  -> %s\n", localProfile, h.TargetDir(config.ScopeLocal, cwd))
 		}
-		fmt.Printf("Local:   %-20s  → %s\n", localProfile, harness.Claude().TargetDir(config.ScopeLocal, cwd))
 
 		return nil
 	},
+}
+
+func init() {
+	statusCmd.Flags().String("harness", "", "Only show one harness")
 }

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -11,13 +11,18 @@ import (
 var useCmd = &cobra.Command{
 	Use:   "use <name>",
 	Short: "Switch to a profile",
-	Long: `Activate a profile. By default switches global (~/.claude/).
-Use --local to switch the project-level profile (.claude/).
+	Long: `Activate a profile for a harness. By default switches global Claude Code config (~/.claude/).
+Use --local to switch the project-level config (.claude/).
+Use --harness to target a specific harness.
 Use --none to go back to vanilla.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		local, _ := cmd.Flags().GetBool("local")
 		none, _ := cmd.Flags().GetBool("none")
+		h, err := harnessFromFlag(cmd)
+		if err != nil {
+			return err
+		}
 
 		scope := config.ScopeGlobal
 		projectPath := ""
@@ -31,10 +36,10 @@ Use --none to go back to vanilla.`,
 		}
 
 		if none {
-			if err := profile.UseNone(scope, projectPath); err != nil {
+			if err := profile.UseNoneWithHarness(scope, projectPath, h); err != nil {
 				return err
 			}
-			fmt.Printf("Switched to vanilla (%s)\n", scope)
+			fmt.Printf("Switched %s harness to vanilla (%s)\n", h.Name(), scope)
 			return nil
 		}
 
@@ -43,10 +48,10 @@ Use --none to go back to vanilla.`,
 		}
 
 		name := args[0]
-		if err := profile.Use(scope, name, projectPath); err != nil {
+		if err := profile.UseWithHarness(scope, name, projectPath, h); err != nil {
 			return err
 		}
-		fmt.Printf("Switched to %q (%s)\n", name, scope)
+		fmt.Printf("Switched %s harness to %q (%s)\n", h.Name(), name, scope)
 		return nil
 	},
 }
@@ -54,4 +59,5 @@ Use --none to go back to vanilla.`,
 func init() {
 	useCmd.Flags().Bool("local", false, "Switch local profile (default: global)")
 	useCmd.Flags().Bool("none", false, "Switch to vanilla (no profile)")
+	useCmd.Flags().String("harness", "", "Harness to target")
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -244,6 +244,59 @@ func TestStatus(t *testing.T) {
 	assertContains(t, out, "statustest")
 }
 
+func TestUseHarnessPersistsActiveByHarness(t *testing.T) {
+	e := newTestEnv(t)
+	e.seedGlobalClaude("# vanilla")
+
+	e.mustRun("global", "init", "work")
+	out := e.mustRun("use", "work", "--harness", "claude")
+	assertContains(t, out, "Switched claude harness")
+
+	statePath := filepath.Join(e.home, ".cvm", "state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+
+	var raw struct {
+		Global struct {
+			Active    string            `json:"active"`
+			Harnesses map[string]string `json:"harnesses"`
+		} `json:"global"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse state: %v", err)
+	}
+	if raw.Global.Harnesses["claude"] != "work" {
+		t.Fatalf("expected claude harness active profile to be work, got state: %s", string(data))
+	}
+	if raw.Global.Active != "work" {
+		t.Fatalf("expected legacy active mirror to be work, got state: %s", string(data))
+	}
+
+	out = e.mustRun("status", "--harness", "claude")
+	assertContains(t, out, "claude harness:")
+	assertContains(t, out, "work")
+
+	e.mustRun("nuke", "--global", "--harness", "claude", "--force")
+	data, err = os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read nuked state: %v", err)
+	}
+	raw = struct {
+		Global struct {
+			Active    string            `json:"active"`
+			Harnesses map[string]string `json:"harnesses"`
+		} `json:"global"`
+	}{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse nuked state: %v", err)
+	}
+	if raw.Global.Harnesses != nil && raw.Global.Harnesses["claude"] != "" {
+		t.Fatalf("expected claude harness to be cleared after nuke, got state: %s", string(data))
+	}
+}
+
 func TestUseSupportsManifestBackedClaudeProfile(t *testing.T) {
 	e := newTestEnv(t)
 	e.seedGlobalClaude("# vanilla")
@@ -496,6 +549,31 @@ func TestRestore(t *testing.T) {
 	data, err := os.ReadFile(claudeMD)
 	if err != nil {
 		t.Fatalf("CLAUDE.md should exist after restore: %v", err)
+	}
+	if !strings.Contains(string(data), "original vanilla content") {
+		t.Fatalf("expected vanilla content, got: %s", string(data))
+	}
+}
+
+func TestRestoreWithHarness(t *testing.T) {
+	e := newTestEnv(t)
+	e.seedGlobalClaude("# original vanilla content")
+
+	e.mustRun("global", "init", "temp")
+	e.mustRun("use", "temp", "--harness", "claude")
+
+	claudeMD := filepath.Join(e.home, ".claude", "CLAUDE.md")
+	if err := os.WriteFile(claudeMD, []byte("# modified by profile"), 0644); err != nil {
+		t.Fatalf("modify CLAUDE.md: %v", err)
+	}
+
+	e.mustRun("nuke", "--global", "--harness", "claude", "--force")
+	out := e.mustRun("restore", "--global", "--harness", "claude")
+	assertContains(t, out, "Restored global config to vanilla")
+
+	data, err := os.ReadFile(claudeMD)
+	if err != nil {
+		t.Fatalf("CLAUDE.md should exist after harness restore: %v", err)
 	}
 	if !strings.Contains(string(data), "original vanilla content") {
 		t.Fatalf("expected vanilla content, got: %s", string(data))

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -34,3 +34,7 @@ func ByName(name string) (Harness, bool) {
 		return nil, false
 	}
 }
+
+func All() []Harness {
+	return []Harness{Claude()}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -41,6 +41,10 @@ func targetDir(scope config.Scope, projectPath string) string {
 	return defaultHarness().TargetDir(scope, projectPath)
 }
 
+func targetDirForHarness(h harness.Harness, scope config.Scope, projectPath string) string {
+	return h.TargetDir(scope, projectPath)
+}
+
 func ProfileDir(scope config.Scope, name string) string {
 	return filepath.Join(profilesDir(scope), name)
 }
@@ -71,7 +75,10 @@ func Init(scope config.Scope, name string, from string, projectPath string) erro
 }
 
 func Use(scope config.Scope, name string, projectPath string) error {
-	h := defaultHarness()
+	return UseWithHarness(scope, name, projectPath, defaultHarness())
+}
+
+func UseWithHarness(scope config.Scope, name string, projectPath string, h harness.Harness) error {
 	profileDir := ProfileDir(scope, name)
 	dir, err := profileAssetDir(profileDir, h)
 	if err != nil {
@@ -87,25 +94,25 @@ func Use(scope config.Scope, name string, projectPath string) error {
 	}
 
 	// Ensure vanilla backup exists
-	if err := EnsureVanilla(scope, projectPath); err != nil {
+	if err := EnsureVanillaWithHarness(scope, projectPath, h); err != nil {
 		return fmt.Errorf("ensuring vanilla backup: %w", err)
 	}
 
 	// Save current state to active profile
 	var currentActive string
 	if scope == config.ScopeGlobal {
-		currentActive = st.Global.Active
+		currentActive = st.GetGlobalHarness(h.Name())
 	} else {
-		currentActive = st.GetLocal(projectPath)
+		currentActive = st.GetLocalHarness(projectPath, h.Name())
 	}
 	if currentActive != "" {
-		if err := Save(scope, currentActive, projectPath); err != nil {
+		if err := SaveWithHarness(scope, currentActive, projectPath, h); err != nil {
 			return fmt.Errorf("saving current active profile %q: %w", currentActive, err)
 		}
 	}
 
 	// Clean and apply
-	tgt := targetDir(scope, projectPath)
+	tgt := targetDirForHarness(h, scope, projectPath)
 	if err := CleanManagedItems(h, scope, tgt, projectPath); err != nil {
 		return fmt.Errorf("cleaning target: %w", err)
 	}
@@ -121,15 +128,18 @@ func Use(scope config.Scope, name string, projectPath string) error {
 
 	// Update state
 	if scope == config.ScopeGlobal {
-		st.SetGlobal(name)
+		st.SetGlobalHarness(h.Name(), name)
 	} else {
-		st.SetLocal(projectPath, name)
+		st.SetLocalHarness(projectPath, h.Name(), name)
 	}
 	return st.Save()
 }
 
 func UseNone(scope config.Scope, projectPath string) error {
-	h := defaultHarness()
+	return UseNoneWithHarness(scope, projectPath, defaultHarness())
+}
+
+func UseNoneWithHarness(scope config.Scope, projectPath string, h harness.Harness) error {
 	st, err := state.Load()
 	if err != nil {
 		return err
@@ -137,33 +147,37 @@ func UseNone(scope config.Scope, projectPath string) error {
 
 	var currentActive string
 	if scope == config.ScopeGlobal {
-		currentActive = st.Global.Active
+		currentActive = st.GetGlobalHarness(h.Name())
 	} else {
-		currentActive = st.GetLocal(projectPath)
+		currentActive = st.GetLocalHarness(projectPath, h.Name())
 	}
 	if currentActive != "" {
-		if err := Save(scope, currentActive, projectPath); err != nil {
+		if err := SaveWithHarness(scope, currentActive, projectPath, h); err != nil {
 			return fmt.Errorf("saving current active profile %q: %w", currentActive, err)
 		}
 	}
 
-	tgt := targetDir(scope, projectPath)
+	tgt := targetDirForHarness(h, scope, projectPath)
 	if err := CleanManagedItems(h, scope, tgt, projectPath); err != nil {
 		return fmt.Errorf("cleaning target: %w", err)
 	}
-	if err := RestoreVanilla(scope, projectPath); err != nil {
+	if err := RestoreVanillaWithHarness(scope, projectPath, h); err != nil {
 		return fmt.Errorf("restoring vanilla backup: %w", err)
 	}
 
 	if scope == config.ScopeGlobal {
-		st.SetGlobal("")
+		st.ClearGlobalHarness(h.Name())
 	} else {
-		st.ClearLocal(projectPath)
+		st.ClearLocalHarness(projectPath, h.Name())
 	}
 	return st.Save()
 }
 
 func List(scope config.Scope, projectPath string) ([]ProfileInfo, error) {
+	return ListWithHarness(scope, projectPath, defaultHarness())
+}
+
+func ListWithHarness(scope config.Scope, projectPath string, h harness.Harness) ([]ProfileInfo, error) {
 	dir := profilesDir(scope)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -180,12 +194,11 @@ func List(scope config.Scope, projectPath string) ([]ProfileInfo, error) {
 
 	var active string
 	if scope == config.ScopeGlobal {
-		active = st.Global.Active
+		active = st.GetGlobalHarness(h.Name())
 	} else {
-		active = st.GetLocal(projectPath)
+		active = st.GetLocalHarness(projectPath, h.Name())
 	}
 
-	h := defaultHarness()
 	var profiles []ProfileInfo
 	for _, e := range entries {
 		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
@@ -206,14 +219,18 @@ func List(scope config.Scope, projectPath string) ([]ProfileInfo, error) {
 }
 
 func Current(scope config.Scope, projectPath string) (string, error) {
+	return CurrentWithHarness(scope, projectPath, defaultHarness())
+}
+
+func CurrentWithHarness(scope config.Scope, projectPath string, h harness.Harness) (string, error) {
 	st, err := state.Load()
 	if err != nil {
 		return "", err
 	}
 	if scope == config.ScopeGlobal {
-		return st.Global.Active, nil
+		return st.GetGlobalHarness(h.Name()), nil
 	}
-	return st.GetLocal(projectPath), nil
+	return st.GetLocalHarness(projectPath, h.Name()), nil
 }
 
 func Inspect(scope config.Scope, name, projectPath string) (*Inventory, error) {
@@ -274,13 +291,16 @@ func Inspect(scope config.Scope, name, projectPath string) (*Inventory, error) {
 }
 
 func Save(scope config.Scope, name string, projectPath string) error {
-	h := defaultHarness()
+	return SaveWithHarness(scope, name, projectPath, defaultHarness())
+}
+
+func SaveWithHarness(scope config.Scope, name string, projectPath string, h harness.Harness) error {
 	profileDir := ProfileDir(scope, name)
 	dir, err := profileAssetDir(profileDir, h)
 	if err != nil {
 		return err
 	}
-	tgt := targetDir(scope, projectPath)
+	tgt := targetDirForHarness(h, scope, projectPath)
 	if _, err := os.Stat(profileDir); os.IsNotExist(err) {
 		return fmt.Errorf("profile %q not found", name)
 	}
@@ -311,9 +331,9 @@ func Remove(scope config.Scope, name string, projectPath string) error {
 	}
 	var active string
 	if scope == config.ScopeGlobal {
-		active = st.Global.Active
+		active = st.GetGlobalHarness(defaultHarness().Name())
 	} else {
-		active = st.GetLocal(projectPath)
+		active = st.GetLocalHarness(projectPath, defaultHarness().Name())
 	}
 	if active == name {
 		return fmt.Errorf("cannot remove active profile %q, switch first with 'cvm %s use --none'", name, scope)
@@ -328,44 +348,70 @@ func Remove(scope config.Scope, name string, projectPath string) error {
 // --- Backup/Vanilla operations (inlined to avoid import cycle) ---
 
 func vanillaDir(scope config.Scope, projectPath string) string {
+	return vanillaDirForHarness(scope, projectPath, defaultHarness())
+}
+
+func vanillaDirForHarness(scope config.Scope, projectPath string, h harness.Harness) string {
+	baseDir := config.GlobalVanillaDir()
 	if scope == config.ScopeGlobal {
-		return config.GlobalVanillaDir()
+		baseDir = config.GlobalVanillaDir()
+	} else {
+		baseDir = config.LocalVanillaDir(projectPath)
 	}
-	return config.LocalVanillaDir(projectPath)
+	if h.Name() == defaultHarness().Name() {
+		return baseDir
+	}
+	return filepath.Join(baseDir, h.Name())
 }
 
 func EnsureVanilla(scope config.Scope, projectPath string) error {
-	vdir := vanillaDir(scope, projectPath)
+	return EnsureVanillaWithHarness(scope, projectPath, defaultHarness())
+}
+
+func EnsureVanillaWithHarness(scope config.Scope, projectPath string, h harness.Harness) error {
+	vdir := vanillaDirForHarness(scope, projectPath, h)
 	if _, err := os.Stat(vdir); err == nil {
 		return nil
 	}
 	if err := os.MkdirAll(vdir, 0755); err != nil {
 		return err
 	}
-	src := targetDir(scope, projectPath)
-	return captureManagedItems(defaultHarness(), scope, src, vdir, projectPath)
+	src := targetDirForHarness(h, scope, projectPath)
+	return captureManagedItems(h, scope, src, vdir, projectPath)
 }
 
 func RestoreVanilla(scope config.Scope, projectPath string) error {
-	vdir := vanillaDir(scope, projectPath)
+	return RestoreVanillaWithHarness(scope, projectPath, defaultHarness())
+}
+
+func RestoreVanillaWithHarness(scope config.Scope, projectPath string, h harness.Harness) error {
+	vdir := vanillaDirForHarness(scope, projectPath, h)
 	if _, err := os.Stat(vdir); os.IsNotExist(err) {
 		return nil
 	}
-	dst := targetDir(scope, projectPath)
+	dst := targetDirForHarness(h, scope, projectPath)
 	if err := os.MkdirAll(dst, 0755); err != nil {
 		return err
 	}
-	return CopyManagedItems(defaultHarness(), scope, vdir, dst, projectPath)
+	return CopyManagedItems(h, scope, vdir, dst, projectPath)
 }
 
 func HasVanilla(scope config.Scope, projectPath string) bool {
-	_, err := os.Stat(vanillaDir(scope, projectPath))
+	return HasVanillaWithHarness(scope, projectPath, defaultHarness())
+}
+
+func HasVanillaWithHarness(scope config.Scope, projectPath string, h harness.Harness) bool {
+	_, err := os.Stat(vanillaDirForHarness(scope, projectPath, h))
 	return err == nil
 }
 
 func Nuke(scope config.Scope, projectPath string) error {
-	dst := targetDir(scope, projectPath)
-	return CleanManagedItems(defaultHarness(), scope, dst, projectPath)
+	return NukeWithHarness(scope, projectPath, defaultHarness())
+}
+
+func NukeWithHarness(scope config.Scope, projectPath string, h harness.Harness) error {
+	dst := targetDirForHarness(h, scope, projectPath)
+	return CleanManagedItems(h, scope, dst, projectPath)
 }
 
 // --- File operations ---

--- a/internal/profile/vanilla_test.go
+++ b/internal/profile/vanilla_test.go
@@ -1,0 +1,87 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chichex/cvm/internal/config"
+	"github.com/chichex/cvm/internal/harness"
+)
+
+type testHarness struct {
+	name      string
+	targetDir string
+}
+
+func (h testHarness) Name() string {
+	return h.name
+}
+
+func (h testHarness) TargetDir(scope config.Scope, projectPath string) string {
+	if scope == config.ScopeLocal {
+		return filepath.Join(projectPath, "."+h.name)
+	}
+	return h.targetDir
+}
+
+func (h testHarness) ManagedDirItems() []string {
+	return []string{"CONFIG.md"}
+}
+
+func (h testHarness) ExternalManagedPath(scope config.Scope, projectPath string) (harness.ManagedPath, bool) {
+	return harness.ManagedPath{}, false
+}
+
+func (h testHarness) ProfileDiscoveryItems() []string {
+	return h.ManagedDirItems()
+}
+
+func (h testHarness) MarkdownInstructionsFile() string {
+	return "CONFIG.md"
+}
+
+func (h testHarness) IsUserMCPPath(profilePath string) bool {
+	return false
+}
+
+func (h testHarness) IsMCPPath(profilePath string) bool {
+	return false
+}
+
+func TestVanillaBackupIsScopedByHarness(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatalf("mkdir claude dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "CLAUDE.md"), []byte("claude vanilla"), 0644); err != nil {
+		t.Fatalf("write claude vanilla: %v", err)
+	}
+	if err := EnsureVanillaWithHarness(config.ScopeGlobal, "", harness.Claude()); err != nil {
+		t.Fatalf("ensure claude vanilla: %v", err)
+	}
+
+	other := testHarness{
+		name:      "opencode",
+		targetDir: filepath.Join(home, ".opencode"),
+	}
+	if err := os.MkdirAll(other.targetDir, 0755); err != nil {
+		t.Fatalf("mkdir other harness dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(other.targetDir, "CONFIG.md"), []byte("opencode vanilla"), 0644); err != nil {
+		t.Fatalf("write other harness vanilla: %v", err)
+	}
+	if err := EnsureVanillaWithHarness(config.ScopeGlobal, "", other); err != nil {
+		t.Fatalf("ensure other harness vanilla: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(config.GlobalVanillaDir(), "CLAUDE.md")); err != nil {
+		t.Fatalf("expected legacy Claude vanilla backup: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(config.GlobalVanillaDir(), other.Name(), "CONFIG.md")); err != nil {
+		t.Fatalf("expected harness-scoped vanilla backup: %v", err)
+	}
+}

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -264,11 +264,11 @@ func Pull(profileName string) ([]string, error) {
 		// the profile dir first, which would overwrite what we just pulled)
 		var active string
 		if scope == config.ScopeGlobal {
-			active = st.Global.Active
+			active = st.GetGlobalHarness("claude")
 		} else {
 			projectPath := resolveLocalProjectPath(st, r)
 			if projectPath != "" {
-				active = st.GetLocal(projectPath)
+				active = st.GetLocalHarness(projectPath, "claude")
 				r.ProjectPath = projectPath
 			}
 		}
@@ -314,8 +314,8 @@ func resolveLocalProjectPath(st *state.State, r state.Remote) string {
 	}
 
 	var match string
-	for projectPath, local := range st.Local {
-		if local.Active != r.Profile {
+	for projectPath := range st.Local {
+		if st.GetLocalHarness(projectPath, "claude") != r.Profile {
 			continue
 		}
 		if match != "" {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -27,11 +27,13 @@ type State struct {
 }
 
 type GlobalState struct {
-	Active string `json:"active"` // empty = vanilla
+	Active    string            `json:"active,omitempty"`    // legacy Claude active profile; empty = vanilla
+	Harnesses map[string]string `json:"harnesses,omitempty"` // use State setters to keep Active mirror in sync
 }
 
 type LocalState struct {
-	Active string `json:"active"` // empty = vanilla
+	Active    string            `json:"active,omitempty"`    // legacy Claude active profile; empty = vanilla
+	Harnesses map[string]string `json:"harnesses,omitempty"` // use State setters to keep Active mirror in sync
 }
 
 // Load reads state from disk. Returns empty state if file doesn't exist.
@@ -56,6 +58,11 @@ func Load() (*State, error) {
 	if s.Local == nil {
 		s.Local = make(map[string]LocalState)
 	}
+	s.Global.normalize()
+	for projectPath, local := range s.Local {
+		local.normalize()
+		s.Local[projectPath] = local
+	}
 	s.Remotes = normalizeRemotes(s.Remotes)
 
 	return s, nil
@@ -78,37 +85,82 @@ func (s *State) Save() error {
 
 // SetGlobal sets the active global profile.
 func (s *State) SetGlobal(name string) {
-	s.Global.Active = name
+	s.SetGlobalHarness("claude", name)
+}
+
+// SetGlobalHarness sets the active global profile for a harness.
+func (s *State) SetGlobalHarness(harnessName, name string) {
+	s.Global.setHarness(harnessName, name)
 }
 
 // SetLocal sets the active local profile for a project path.
 func (s *State) SetLocal(projectPath, name string) {
+	s.SetLocalHarness(projectPath, "claude", name)
+}
+
+// SetLocalHarness sets the active local profile for a project path and harness.
+func (s *State) SetLocalHarness(projectPath, harnessName, name string) {
 	abs, err := filepath.Abs(projectPath)
 	if err != nil {
 		abs = projectPath
 	}
-	s.Local[abs] = LocalState{Active: name}
+	ls := s.Local[abs]
+	ls.setHarness(harnessName, name)
+	if ls.isEmpty() {
+		delete(s.Local, abs)
+		return
+	}
+	s.Local[abs] = ls
 }
 
 // GetLocal returns the active local profile for a project path.
 func (s *State) GetLocal(projectPath string) string {
+	return s.GetLocalHarness(projectPath, "claude")
+}
+
+// GetGlobalHarness returns the active global profile for a harness.
+func (s *State) GetGlobalHarness(harnessName string) string {
+	return s.Global.getHarness(harnessName)
+}
+
+// GetLocalHarness returns the active local profile for a project path and harness.
+func (s *State) GetLocalHarness(projectPath, harnessName string) string {
 	abs, err := filepath.Abs(projectPath)
 	if err != nil {
 		abs = projectPath
 	}
 	if ls, ok := s.Local[abs]; ok {
-		return ls.Active
+		return ls.getHarness(harnessName)
 	}
 	return ""
 }
 
 // ClearLocal removes local state for a project path.
 func (s *State) ClearLocal(projectPath string) {
+	s.ClearLocalHarness(projectPath, "claude")
+}
+
+// ClearGlobalHarness clears the active global profile for a harness.
+func (s *State) ClearGlobalHarness(harnessName string) {
+	s.SetGlobalHarness(harnessName, "")
+}
+
+// ClearLocalHarness clears the active local profile for a project path and harness.
+func (s *State) ClearLocalHarness(projectPath, harnessName string) {
 	abs, err := filepath.Abs(projectPath)
 	if err != nil {
 		abs = projectPath
 	}
-	delete(s.Local, abs)
+	ls, ok := s.Local[abs]
+	if !ok {
+		return
+	}
+	ls.setHarness(harnessName, "")
+	if ls.isEmpty() {
+		delete(s.Local, abs)
+		return
+	}
+	s.Local[abs] = ls
 }
 
 // PutRemote stores a remote using a composite key so global and local remotes
@@ -212,4 +264,71 @@ func normalizeProjectPath(projectPath string) string {
 		return projectPath
 	}
 	return abs
+}
+
+func (gs *GlobalState) normalize() {
+	gs.Harnesses = normalizeHarnesses(gs.Active, gs.Harnesses)
+	gs.Active = gs.Harnesses["claude"]
+}
+
+func (gs *GlobalState) getHarness(harnessName string) string {
+	if gs.Harnesses != nil {
+		return gs.Harnesses[harnessName]
+	}
+	if harnessName == "claude" {
+		return gs.Active
+	}
+	return ""
+}
+
+func (gs *GlobalState) setHarness(harnessName, name string) {
+	gs.Harnesses = setHarness(gs.Active, gs.Harnesses, harnessName, name)
+	gs.Active = gs.Harnesses["claude"]
+}
+
+func (ls *LocalState) normalize() {
+	ls.Harnesses = normalizeHarnesses(ls.Active, ls.Harnesses)
+	ls.Active = ls.Harnesses["claude"]
+}
+
+func (ls *LocalState) getHarness(harnessName string) string {
+	if ls.Harnesses != nil {
+		return ls.Harnesses[harnessName]
+	}
+	if harnessName == "claude" {
+		return ls.Active
+	}
+	return ""
+}
+
+func (ls *LocalState) setHarness(harnessName, name string) {
+	ls.Harnesses = setHarness(ls.Active, ls.Harnesses, harnessName, name)
+	ls.Active = ls.Harnesses["claude"]
+}
+
+func (ls LocalState) isEmpty() bool {
+	return ls.Active == "" && len(ls.Harnesses) == 0
+}
+
+func normalizeHarnesses(legacyActive string, harnesses map[string]string) map[string]string {
+	normalized := make(map[string]string)
+	for harnessName, active := range harnesses {
+		if active != "" {
+			normalized[harnessName] = active
+		}
+	}
+	if _, ok := normalized["claude"]; !ok && legacyActive != "" {
+		normalized["claude"] = legacyActive
+	}
+	return normalized
+}
+
+func setHarness(legacyActive string, harnesses map[string]string, harnessName, name string) map[string]string {
+	normalized := normalizeHarnesses(legacyActive, harnesses)
+	if name == "" {
+		delete(normalized, harnessName)
+		return normalized
+	}
+	normalized[harnessName] = name
+	return normalized
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -97,3 +97,70 @@ func TestLoadMigratesLegacyRemoteKeys(t *testing.T) {
 		t.Fatalf("unexpected migrated repo: %s", remote.Repo)
 	}
 }
+
+func TestLoadInterpretsLegacyActiveAsClaudeHarness(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	raw := map[string]any{
+		"global": map[string]any{"active": "work"},
+		"local": map[string]any{
+			"/tmp/project": map[string]any{"active": "dev"},
+		},
+	}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal legacy state: %v", err)
+	}
+	if err := os.MkdirAll(config.CvmHome(), 0755); err != nil {
+		t.Fatalf("mkdir cvm home: %v", err)
+	}
+	if err := os.WriteFile(config.StatePath(), data, 0644); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	st, err := Load()
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+
+	if got := st.GetGlobalHarness("claude"); got != "work" {
+		t.Fatalf("expected legacy global active to map to claude, got %q", got)
+	}
+	if got := st.GetLocalHarness("/tmp/project", "claude"); got != "dev" {
+		t.Fatalf("expected legacy local active to map to claude, got %q", got)
+	}
+	if got := st.GetGlobalHarness("opencode"); got != "" {
+		t.Fatalf("expected unrelated harness to stay vanilla, got %q", got)
+	}
+}
+
+func TestHarnessStateDoesNotOverwriteOtherHarnesses(t *testing.T) {
+	st := &State{
+		Local:   make(map[string]LocalState),
+		Remotes: make(map[string]Remote),
+	}
+
+	st.SetGlobalHarness("claude", "work")
+	st.SetGlobalHarness("opencode", "open")
+	st.ClearGlobalHarness("claude")
+
+	if got := st.GetGlobalHarness("claude"); got != "" {
+		t.Fatalf("expected claude to be vanilla, got %q", got)
+	}
+	if got := st.GetGlobalHarness("opencode"); got != "open" {
+		t.Fatalf("expected opencode to remain active, got %q", got)
+	}
+
+	st.SetLocalHarness("/tmp/project", "claude", "dev")
+	st.SetLocalHarness("/tmp/project", "opencode", "open-dev")
+	st.ClearLocalHarness("/tmp/project", "claude")
+
+	if got := st.GetLocalHarness("/tmp/project", "claude"); got != "" {
+		t.Fatalf("expected local claude to be vanilla, got %q", got)
+	}
+	if got := st.GetLocalHarness("/tmp/project", "opencode"); got != "open-dev" {
+		t.Fatalf("expected local opencode to remain active, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Store active profiles per harness while keeping legacy Claude active state compatible
- Add --harness targeting for use, status, nuke, and restore
- Add state/e2e coverage and update README usage

Closes #35

## Test
- go test ./...