### PR TITLE
Add OpenCode harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ cvm override rm skill foo        # remove an override file
 | **global** (default) | `~/.claude/` plus `~/.claude.json` | `~/.config/opencode/` or `$OPENCODE_CONFIG_DIR` | (none) |
 | **local** | `.claude/` plus `.mcp.json` in current project | `.opencode/` in current project | `--local` |
 
+For OpenCode, `opencode.json` lives inside the target dir and is user-owned; `cvm` only manages its `mcpServers` section.
+
 ## What cvm manages
 
 ### Claude
@@ -183,12 +185,12 @@ OpenCode support is intentionally limited to portable assets copied as-is into O
 | Item | Description |
 |------|-------------|
 | `AGENTS.md` | Harness instructions |
-| `opencode.json` | OpenCode configuration, including `mcpServers` when present |
+| `opencode.json` | OpenCode configuration, managed only as the `mcpServers` section |
 | `skills/` | OpenCode skills in native format |
 | `agents/` | OpenCode agent definitions in native format |
 | `commands/` | OpenCode commands in native format |
 
-`cvm` does not translate Claude-specific assets for OpenCode. `CLAUDE.md`, Claude `settings.json`, hooks, plugins, and other non-portable behavior require profile-author adaptation and are not promised compatible.
+`cvm` does not translate Claude-specific assets for OpenCode. `CLAUDE.md`, Claude `settings.json`, hooks, plugins, non-MCP top-level `opencode.json` settings, and other non-portable behavior require profile-author adaptation and are not promised compatible.
 
 OpenCode runtime storage is **never** touched, including `~/.local/share/opencode/`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cvm - Claude Version Manager
 
-Profile manager for [Claude Code](https://claude.ai/code). Switch entire configurations instantly, nuke everything, restore to vanilla. Like `nvm` but for your Claude Code setup.
+Profile manager for agent harnesses, starting with [Claude Code](https://claude.ai/code) and OpenCode. Switch configurations instantly, nuke everything, restore to vanilla. Like `nvm` but for your agent setup.
 
 ## Why
 
@@ -68,6 +68,7 @@ When adding from a repo without a path, cvm auto-discovers the profile:
 cvm use work            # activate globally (~/.claude/)
 cvm use work --local    # activate for current project (.claude/)
 cvm use work --harness claude
+cvm use work --harness opencode
 cvm use --none          # back to vanilla
 ```
 
@@ -100,6 +101,7 @@ cvm restore             # restore pre-cvm state from vanilla backup
 cvm restore --global    # only global
 cvm restore --local     # only local
 cvm restore --harness claude
+cvm restore --harness opencode
 ```
 
 ### Remote management
@@ -114,6 +116,7 @@ cvm remote rm chiche   # unlink from remote (keeps local copy)
 ```bash
 cvm status             # show active profiles by harness (global + local)
 cvm status --harness claude
+cvm status --harness opencode
 cvm profile            # inspect active profile contents
 cvm profile show work  # inspect a specific stored profile
 ```
@@ -145,12 +148,14 @@ cvm override rm skill foo        # remove an override file
 
 ## Two scopes
 
-| Scope | What it manages | Flag |
-|-------|----------------|------|
-| **global** (default) | `~/.claude/` — applies to all projects | (none) |
-| **local** | `.claude/` in current project | `--local` |
+| Scope | Claude target | OpenCode target | Flag |
+|-------|---------------|-----------------|------|
+| **global** (default) | `~/.claude/` plus `~/.claude.json` | `~/.config/opencode/` or `$OPENCODE_CONFIG_DIR` | (none) |
+| **local** | `.claude/` plus `.mcp.json` in current project | `.opencode/` in current project | `--local` |
 
 ## What cvm manages
+
+### Claude
 
 | Item | Description |
 |------|-------------|
@@ -170,6 +175,22 @@ cvm override rm skill foo        # remove an override file
 | `statusline-command.sh` | Status bar script |
 
 Runtime data is **never** touched: `sessions/`, `cache/`, `history.jsonl`, `transcripts/`, `projects/` (auto-memory), `plugins/`.
+
+### OpenCode
+
+OpenCode support is intentionally limited to portable assets copied as-is into OpenCode's native config directories.
+
+| Item | Description |
+|------|-------------|
+| `AGENTS.md` | Harness instructions |
+| `opencode.json` | OpenCode configuration, including `mcpServers` when present |
+| `skills/` | OpenCode skills in native format |
+| `agents/` | OpenCode agent definitions in native format |
+| `commands/` | OpenCode commands in native format |
+
+`cvm` does not translate Claude-specific assets for OpenCode. `CLAUDE.md`, Claude `settings.json`, hooks, plugins, and other non-portable behavior require profile-author adaptation and are not promised compatible.
+
+OpenCode runtime storage is **never** touched, including `~/.local/share/opencode/`.
 
 ## How switching works
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -341,6 +341,76 @@ func TestUseSupportsManifestBackedClaudeProfile(t *testing.T) {
 	}
 }
 
+func TestOpenCodeHarnessGlobalWorkflow(t *testing.T) {
+	e := newTestEnv(t)
+
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "open")
+	writeTestFile(t, filepath.Join(profileRoot, "cvm.profile.toml"), "name = \"open\"\nharnesses = [\"opencode\"]\n\n[assets]\nopencode = \"opencode\"\n")
+	writeTestFile(t, filepath.Join(profileRoot, "opencode", "AGENTS.md"), "# opencode profile")
+	writeTestFile(t, filepath.Join(profileRoot, "opencode", "skills", "deploy", "SKILL.md"), "---\nname: deploy\ndescription: Deploy app\n---\n")
+	writeTestFile(t, filepath.Join(profileRoot, "opencode", "opencode.json"), `{"mcpServers":{"context7":{"type":"local"}}}`)
+
+	out := e.mustRun("use", "open", "--harness", "opencode")
+	assertContains(t, out, "Switched opencode harness")
+
+	opencodeDir := filepath.Join(e.home, ".config", "opencode")
+	assertFileContent(t, filepath.Join(opencodeDir, "AGENTS.md"), "# opencode profile")
+	if _, err := os.Stat(filepath.Join(opencodeDir, "skills", "deploy", "SKILL.md")); err != nil {
+		t.Fatalf("expected opencode skill to be installed: %v", err)
+	}
+	assertMCPServerExists(t, filepath.Join(opencodeDir, "opencode.json"), "context7")
+	if _, err := os.Stat(filepath.Join(e.home, ".claude", "AGENTS.md")); err == nil {
+		t.Fatal("opencode use should not install into Claude paths")
+	}
+
+	out = e.mustRun("status", "--harness", "opencode")
+	assertContains(t, out, "opencode harness:")
+	assertContains(t, out, "open")
+	assertContains(t, out, filepath.Join(e.home, ".config", "opencode"))
+
+	e.mustRun("nuke", "--global", "--harness", "opencode", "--force")
+	if _, err := os.Stat(filepath.Join(opencodeDir, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected opencode AGENTS.md to be nuked, got err %v", err)
+	}
+}
+
+func TestOpenCodeHarnessRestoreGlobalVanilla(t *testing.T) {
+	e := newTestEnv(t)
+	opencodeDir := filepath.Join(e.home, ".config", "opencode")
+	writeTestFile(t, filepath.Join(opencodeDir, "AGENTS.md"), "# vanilla opencode")
+
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "open")
+	writeTestFile(t, filepath.Join(profileRoot, "cvm.profile.toml"), "name = \"open\"\nharnesses = [\"opencode\"]\n\n[assets]\nopencode = \"opencode\"\n")
+	writeTestFile(t, filepath.Join(profileRoot, "opencode", "AGENTS.md"), "# profile opencode")
+
+	e.mustRun("use", "open", "--harness", "opencode")
+	assertFileContent(t, filepath.Join(opencodeDir, "AGENTS.md"), "# profile opencode")
+
+	out := e.mustRun("restore", "--global", "--harness", "opencode")
+	assertContains(t, out, "Restored global config to vanilla (opencode harness)")
+	assertFileContent(t, filepath.Join(opencodeDir, "AGENTS.md"), "# vanilla opencode")
+}
+
+func TestOpenCodeHarnessLocalWorkflow(t *testing.T) {
+	e := newTestEnv(t)
+
+	profileRoot := filepath.Join(e.home, ".cvm", "local", "profiles", "open-local")
+	writeTestFile(t, filepath.Join(profileRoot, "cvm.profile.toml"), "name = \"open-local\"\nharnesses = [\"opencode\"]\n\n[assets]\nopencode = \"opencode\"\n")
+	writeTestFile(t, filepath.Join(profileRoot, "opencode", "AGENTS.md"), "# local opencode profile")
+
+	out := e.mustRun("use", "open-local", "--local", "--harness", "opencode")
+	assertContains(t, out, "Switched opencode harness")
+	assertFileContent(t, filepath.Join(e.projectDir, ".opencode", "AGENTS.md"), "# local opencode profile")
+	if _, err := os.Stat(filepath.Join(e.home, ".config", "opencode", "AGENTS.md")); err == nil {
+		t.Fatal("local opencode use should not install into global OpenCode paths")
+	}
+
+	e.mustRun("nuke", "--local", "--harness", "opencode", "--force")
+	if _, err := os.Stat(filepath.Join(e.projectDir, ".opencode", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected local opencode AGENTS.md to be nuked, got err %v", err)
+	}
+}
+
 func TestManifestBackedProfileOverridesRestoreFromAssetDir(t *testing.T) {
 	e := newTestEnv(t)
 	e.seedGlobalClaude("# vanilla")
@@ -957,6 +1027,18 @@ func assertJSONKeyExists(t *testing.T, path, want string) {
 	}
 	if _, ok := cfg[want]; !ok {
 		t.Fatalf("json %s missing key %q", path, want)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if strings.TrimSpace(string(data)) != want {
+		t.Fatalf("%s content = %q, want %q", path, strings.TrimSpace(string(data)), want)
 	}
 }
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -343,6 +343,8 @@ func TestUseSupportsManifestBackedClaudeProfile(t *testing.T) {
 
 func TestOpenCodeHarnessGlobalWorkflow(t *testing.T) {
 	e := newTestEnv(t)
+	opencodeDir := filepath.Join(e.home, ".config", "opencode")
+	writeTestFile(t, filepath.Join(opencodeDir, "opencode.json"), `{"theme":"system","mcpServers":{"user-server":{"type":"local"}}}`)
 
 	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "open")
 	writeTestFile(t, filepath.Join(profileRoot, "cvm.profile.toml"), "name = \"open\"\nharnesses = [\"opencode\"]\n\n[assets]\nopencode = \"opencode\"\n")
@@ -353,11 +355,11 @@ func TestOpenCodeHarnessGlobalWorkflow(t *testing.T) {
 	out := e.mustRun("use", "open", "--harness", "opencode")
 	assertContains(t, out, "Switched opencode harness")
 
-	opencodeDir := filepath.Join(e.home, ".config", "opencode")
 	assertFileContent(t, filepath.Join(opencodeDir, "AGENTS.md"), "# opencode profile")
 	if _, err := os.Stat(filepath.Join(opencodeDir, "skills", "deploy", "SKILL.md")); err != nil {
 		t.Fatalf("expected opencode skill to be installed: %v", err)
 	}
+	assertJSONKeyExists(t, filepath.Join(opencodeDir, "opencode.json"), "theme")
 	assertMCPServerExists(t, filepath.Join(opencodeDir, "opencode.json"), "context7")
 	if _, err := os.Stat(filepath.Join(e.home, ".claude", "AGENTS.md")); err == nil {
 		t.Fatal("opencode use should not install into Claude paths")
@@ -372,6 +374,8 @@ func TestOpenCodeHarnessGlobalWorkflow(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(opencodeDir, "AGENTS.md")); !os.IsNotExist(err) {
 		t.Fatalf("expected opencode AGENTS.md to be nuked, got err %v", err)
 	}
+	assertJSONKeyExists(t, filepath.Join(opencodeDir, "opencode.json"), "theme")
+	assertMCPServerNotExists(t, filepath.Join(opencodeDir, "opencode.json"), "context7")
 }
 
 func TestOpenCodeHarnessRestoreGlobalVanilla(t *testing.T) {
@@ -1010,6 +1014,25 @@ func assertMCPServerExists(t *testing.T, path, want string) {
 	}
 	if _, ok := cfg.MCPServers[want]; !ok {
 		t.Fatalf("settings %s missing mcp server %q", path, want)
+	}
+}
+
+func assertMCPServerNotExists(t *testing.T, path, notWant string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings %s: %v", path, err)
+	}
+
+	var cfg struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal settings %s: %v", path, err)
+	}
+	if _, ok := cfg.MCPServers[notWant]; ok {
+		t.Fatalf("settings %s should not contain mcp server %q", path, notWant)
 	}
 }
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -30,11 +30,13 @@ func ByName(name string) (Harness, bool) {
 	switch name {
 	case "claude":
 		return Claude(), true
+	case "opencode":
+		return OpenCode(), true
 	default:
 		return nil, false
 	}
 }
 
 func All() []Harness {
-	return []Harness{Claude()}
+	return []Harness{Claude(), OpenCode()}
 }

--- a/internal/harness/opencode.go
+++ b/internal/harness/opencode.go
@@ -1,0 +1,61 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/chichex/cvm/internal/config"
+)
+
+type opencodeHarness struct{}
+
+var managedOpenCodeDirItems = []string{
+	"AGENTS.md",
+	"opencode.json",
+	"skills",
+	"agents",
+	"commands",
+}
+
+func OpenCode() Harness {
+	return opencodeHarness{}
+}
+
+func (opencodeHarness) Name() string {
+	return "opencode"
+}
+
+func (opencodeHarness) TargetDir(scope config.Scope, projectPath string) string {
+	if scope == config.ScopeLocal {
+		return filepath.Join(projectPath, ".opencode")
+	}
+	if dir := os.Getenv("OPENCODE_CONFIG_DIR"); dir != "" {
+		return dir
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "opencode")
+}
+
+func (opencodeHarness) ManagedDirItems() []string {
+	return append([]string{}, managedOpenCodeDirItems...)
+}
+
+func (opencodeHarness) ExternalManagedPath(scope config.Scope, projectPath string) (ManagedPath, bool) {
+	return ManagedPath{}, false
+}
+
+func (h opencodeHarness) ProfileDiscoveryItems() []string {
+	return h.ManagedDirItems()
+}
+
+func (opencodeHarness) MarkdownInstructionsFile() string {
+	return "AGENTS.md"
+}
+
+func (opencodeHarness) IsUserMCPPath(profilePath string) bool {
+	return false
+}
+
+func (opencodeHarness) IsMCPPath(profilePath string) bool {
+	return profilePath == "opencode.json"
+}

--- a/internal/harness/opencode.go
+++ b/internal/harness/opencode.go
@@ -11,6 +11,7 @@ type opencodeHarness struct{}
 
 var managedOpenCodeDirItems = []string{
 	"AGENTS.md",
+	// Only mcpServers inside opencode.json are managed; other user config is preserved.
 	"opencode.json",
 	"skills",
 	"agents",
@@ -27,6 +28,7 @@ func (opencodeHarness) Name() string {
 
 func (opencodeHarness) TargetDir(scope config.Scope, projectPath string) string {
 	if scope == config.ScopeLocal {
+		// OPENCODE_CONFIG_DIR only redirects the global config; project config remains local.
 		return filepath.Join(projectPath, ".opencode")
 	}
 	if dir := os.Getenv("OPENCODE_CONFIG_DIR"); dir != "" {
@@ -41,6 +43,7 @@ func (opencodeHarness) ManagedDirItems() []string {
 }
 
 func (opencodeHarness) ExternalManagedPath(scope config.Scope, projectPath string) (ManagedPath, bool) {
+	// OpenCode keeps config inside TargetDir, unlike Claude's external MCP files.
 	return ManagedPath{}, false
 }
 
@@ -53,7 +56,7 @@ func (opencodeHarness) MarkdownInstructionsFile() string {
 }
 
 func (opencodeHarness) IsUserMCPPath(profilePath string) bool {
-	return false
+	return profilePath == "opencode.json"
 }
 
 func (opencodeHarness) IsMCPPath(profilePath string) bool {

--- a/internal/harness/opencode_test.go
+++ b/internal/harness/opencode_test.go
@@ -1,0 +1,34 @@
+package harness
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/chichex/cvm/internal/config"
+)
+
+func TestOpenCodeTargetDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	h := OpenCode()
+	if got, want := h.TargetDir(config.ScopeGlobal, ""), filepath.Join(home, ".config", "opencode"); got != want {
+		t.Fatalf("global target = %q, want %q", got, want)
+	}
+
+	project := filepath.Join(home, "project")
+	if got, want := h.TargetDir(config.ScopeLocal, project), filepath.Join(project, ".opencode"); got != want {
+		t.Fatalf("local target = %q, want %q", got, want)
+	}
+}
+
+func TestOpenCodeTargetDirUsesConfigEnv(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-opencode")
+	t.Setenv("HOME", home)
+	t.Setenv("OPENCODE_CONFIG_DIR", custom)
+
+	if got := OpenCode().TargetDir(config.ScopeGlobal, ""); got != custom {
+		t.Fatalf("global target with OPENCODE_CONFIG_DIR = %q, want %q", got, custom)
+	}
+}

--- a/internal/profile/manifest_test.go
+++ b/internal/profile/manifest_test.go
@@ -30,7 +30,7 @@ func TestLoadManifestDefaultsToClaudeRoot(t *testing.T) {
 
 func TestLoadManifestSupportsHarnessSpecificAssetDir(t *testing.T) {
 	dir := t.TempDir()
-	body := []byte("name = \"lite\"\nharnesses = [\"claude\", \"codex\"]\n\n[assets]\nclaude = \"claude\"\ncodex = \"codex\"\n")
+	body := []byte("name = \"lite\"\nharnesses = [\"claude\", \"opencode\"]\n\n[assets]\nclaude = \"claude\"\nopencode = \"opencode\"\n")
 	if err := os.WriteFile(filepath.Join(dir, manifestFileName), body, 0644); err != nil {
 		t.Fatalf("write manifest: %v", err)
 	}
@@ -39,8 +39,8 @@ func TestLoadManifestSupportsHarnessSpecificAssetDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadManifest: %v", err)
 	}
-	if !manifest.SupportsHarness("codex") {
-		t.Fatal("manifest should support codex")
+	if !manifest.SupportsHarness("opencode") {
+		t.Fatal("manifest should support opencode")
 	}
 
 	assetDir, err := manifest.AssetDir(dir, harness.Claude())


### PR DESCRIPTION
## Summary
- Add an OpenCode harness with native global/local targets and portable managed assets.
- Cover OpenCode use/status/nuke/restore flows with e2e tests plus target path unit tests.
- Document OpenCode support boundaries and non-portable assets that require profile author adaptation.

## Tests
- go test ./...

Closes #36