### PR TITLE
Define portable profile contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,15 +167,16 @@ harnesses = ["claude"]
 
 [assets]
 portable = "portable"
-claude = "claude"
-opencode = "opencode"
+claude = "."
 ```
 
-Portable v1 is intentionally small: `instructions`, `skills`, instruction-only `agents`, and conceptual `settings`. Hooks, plugins, MCP with incompatible formats, raw vendor settings, runtime memory, transcripts, sessions, and caches are not portable and must live in harness-specific override directories.
+Portable v0.1 is experimental and intentionally small: `instructions`, portable `skills`, instruction-only `agents`, and conceptual `settings`. Everything else is harness-specific by default, including hooks, plugins, MCP with incompatible formats, raw vendor settings, statusline commands, keybindings, output styles, teams, path rules, runtime memory, transcripts, sessions, and caches.
+
+Portable skills must not assume harness-specific subagents, harness filesystem paths, or cross-skill contracts tied to harness output conventions.
 
 If a harness-specific asset dir is not declared, `cvm` can use `[assets].portable` as the fallback. Legacy profiles without a manifest still behave as Claude profiles rooted at the profile directory.
 
-See `specs/portable-profiles.md` for the full contract and merge model.
+See `specs/portable-profiles.md` for the full experimental contract and merge model.
 
 ### Claude
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,26 @@ For OpenCode, `opencode.json` lives inside the target dir and is user-owned; `cv
 
 ## What cvm manages
 
+### Portable profiles
+
+Profiles can opt into `cvm.profile.toml` to describe supported harnesses and asset directories:
+
+```toml
+name = "lite"
+harnesses = ["claude"]
+
+[assets]
+portable = "portable"
+claude = "claude"
+opencode = "opencode"
+```
+
+Portable v1 is intentionally small: `instructions`, `skills`, instruction-only `agents`, and conceptual `settings`. Hooks, plugins, MCP with incompatible formats, raw vendor settings, runtime memory, transcripts, sessions, and caches are not portable and must live in harness-specific override directories.
+
+If a harness-specific asset dir is not declared, `cvm` can use `[assets].portable` as the fallback. Legacy profiles without a manifest still behave as Claude profiles rooted at the profile directory.
+
+See `specs/portable-profiles.md` for the full contract and merge model.
+
 ### Claude
 
 | Item | Description |
@@ -207,6 +227,8 @@ When you run `cvm use work`:
 ## The "lite" profile
 
 A **minimalist profile** for subagent orchestration. No specs, no complex hooks — just skills and Claude Code's built-in auto-memory (`~/.claude/projects/<path>/memory/`).
+
+`lite` declares the portable profile contract and includes neutral instructions in `profiles/lite/portable/instructions.md`, but it currently supports only Claude. Its skills, MCP config, statusline, and memory behavior are Claude-specific until OpenCode/Codex renderers can map the portable subset safely.
 
 Skills:
 

--- a/internal/profile/manifest.go
+++ b/internal/profile/manifest.go
@@ -105,6 +105,9 @@ func (m *Manifest) SupportsHarness(name string) bool {
 
 func (m *Manifest) AssetDir(profileDir string, h harness.Harness) (string, error) {
 	raw := strings.TrimSpace(m.Assets[h.Name()])
+	if raw == "" {
+		raw = strings.TrimSpace(m.Assets["portable"])
+	}
 	if raw == "" || raw == "." {
 		return profileDir, nil
 	}

--- a/internal/profile/manifest_test.go
+++ b/internal/profile/manifest_test.go
@@ -53,6 +53,28 @@ func TestLoadManifestSupportsHarnessSpecificAssetDir(t *testing.T) {
 	}
 }
 
+func TestLoadManifestUsesPortableAssetDirAsHarnessFallback(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("name = \"lite\"\nharnesses = [\"claude\"]\n\n[assets]\nportable = \"portable\"\n")
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), body, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+
+	assetDir, err := manifest.AssetDir(dir, harness.Claude())
+	if err != nil {
+		t.Fatalf("AssetDir: %v", err)
+	}
+	want := filepath.Join(dir, "portable")
+	if assetDir != want {
+		t.Fatalf("unexpected asset dir: got %q want %q", assetDir, want)
+	}
+}
+
 func TestManifestRejectsEscapingAssetDir(t *testing.T) {
 	dir := t.TempDir()
 	body := []byte("harnesses = [\"claude\"]\n\n[assets]\nclaude = \"../escape\"\n")

--- a/internal/profile/manifest_test.go
+++ b/internal/profile/manifest_test.go
@@ -75,6 +75,27 @@ func TestLoadManifestUsesPortableAssetDirAsHarnessFallback(t *testing.T) {
 	}
 }
 
+func TestLoadManifestTreatsExplicitEmptyAssetDirAsProfileRoot(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("name = \"lite\"\nharnesses = [\"claude\"]\n\n[assets]\nportable = \"\"\nclaude = \"\"\n")
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), body, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+
+	assetDir, err := manifest.AssetDir(dir, harness.Claude())
+	if err != nil {
+		t.Fatalf("AssetDir: %v", err)
+	}
+	if assetDir != dir {
+		t.Fatalf("unexpected asset dir: got %q want %q", assetDir, dir)
+	}
+}
+
 func TestManifestRejectsEscapingAssetDir(t *testing.T) {
 	dir := t.TempDir()
 	body := []byte("harnesses = [\"claude\"]\n\n[assets]\nclaude = \"../escape\"\n")

--- a/profiles/lite/cvm.profile.toml
+++ b/profiles/lite/cvm.profile.toml
@@ -1,0 +1,6 @@
+name = "lite"
+harnesses = ["claude"]
+
+[assets]
+portable = "portable"
+claude = "."

--- a/profiles/lite/portable/instructions.md
+++ b/profiles/lite/portable/instructions.md
@@ -1,0 +1,29 @@
+# Lite Profile
+
+## Skills
+
+| Skill | Que hace |
+|-------|----------|
+| `/go` | Subagent unificado; default Opus; `--codex` / `--gemini` para validacion externa |
+| `/r` | Review de sesion y persistencia de learnings en project memory. Soporta `/r --dry-run` |
+| `/ux` | Iteracion UX con validacion multi y HTML de alternativas |
+| `/che-idea` | Crear GitHub issue desde idea vaga; aplica `che:idea` + `ct:plan` |
+| `/che-explore` | Analizar issue, prepender plan consolidado y comentar paths/riesgos; aplica `che:planning` -> `che:plan` |
+| `/che-execute` | Implementar issue/tarea en worktree aislado y abrir PR draft; aplica `che:executing` -> `che:executed` |
+| `/che-validate` | Revisar PR/issue con subagentes paralelos y emitir verdict |
+| `/che-iterate` | Aplicar comments/reviews sobre PR o issue |
+| `/che-loop` | Automatizar `che-validate` -> `che-iterate` hasta aprobacion, sin comments accionables, limite o idempotencia |
+| `/che-close` | Ready-for-review, esperar CI, mergear y cerrar issues linkeados |
+
+## Rules
+
+- Resolve ambiguity before acting when a request can be interpreted in more than one way.
+- Use TDD when feasible.
+- Do not add work that was not requested.
+- Do not speculate about code without reading it first.
+- Keep responses short and direct.
+- On macOS, avoid GNU-only flags such as `grep -P`; use `grep -E`.
+
+## Claude-Specific Behavior
+
+The current `lite` profile remains Claude-only. Its installed skills rely on Claude Code skills, project auto-memory under `~/.claude/projects/<path>/memory/`, and Claude-specific settings/MCP files. Other harnesses should use this file as the neutral starting point, not as a promise of full compatibility.

--- a/specs/REGISTRY.md
+++ b/specs/REGISTRY.md
@@ -1,3 +1,4 @@
 | ID | Nombre | Status | Version | Validacion | Archivo |
 |----|--------|--------|---------|------------|---------|
 | S-012 | multi-validator | implemented | 0.2.0 | manual | specs/multi-validator.spec.md |
+| S-013 | portable-profiles | planned | 0.1.0 | tests | specs/portable-profiles.md |

--- a/specs/REGISTRY.md
+++ b/specs/REGISTRY.md
@@ -1,4 +1,4 @@
 | ID | Nombre | Status | Version | Validacion | Archivo |
 |----|--------|--------|---------|------------|---------|
 | S-012 | multi-validator | implemented | 0.2.0 | manual | specs/multi-validator.spec.md |
-| S-013 | portable-profiles | planned | 0.1.0 | tests | specs/portable-profiles.md |
+| S-013 | portable-profiles | planned | 0.1.0 | manual | specs/portable-profiles.md |

--- a/specs/portable-profiles.md
+++ b/specs/portable-profiles.md
@@ -1,0 +1,82 @@
+# Portable Profile Contract v1
+
+## Goal
+
+Define the small profile surface that `cvm` owns across harnesses. Portable assets are authored as `cvm` concepts first, then rendered or copied into Claude, OpenCode, Codex, or another harness when that harness has a compatible equivalent.
+
+## Portable Rule
+
+An asset is portable when all of these are true:
+
+- `cvm` owns the concept, not a specific harness.
+- The concept can be installed into more than one harness without guessing user intent.
+- A missing or partial harness equivalent can be omitted or degraded explicitly.
+- The mapping is 1:1 or close to 1:1.
+
+If an asset requires semantic translation, behavior rewrites, or runtime-specific hooks, it is not portable v1.
+
+## Included Assets
+
+| Asset | Format | Notes |
+|-------|--------|-------|
+| `instructions` | `portable/instructions.md` | Base profile instructions in neutral Markdown. Harness renderers choose the target filename, such as `CLAUDE.md` or `AGENTS.md`. |
+| `skills` | `portable/skills/<name>.md` | Prompt assets with minimal frontmatter. Harness renderers may wrap them in native `SKILL.md` layout. |
+| `agents` | `portable/agents/<name>.md` | Instruction-only agent definitions. Native agent config remains harness-specific. |
+| `settings` | `portable/settings.toml` | Only conceptual settings with shared semantics, such as approval or sandbox policy. |
+
+## Excluded Assets
+
+These assets are harness-specific in portable v1:
+
+- hooks
+- plugins
+- commands legacy
+- MCP config with incompatible formats
+- raw vendor settings files
+- runtime-specific memory, transcript, session, or cache data
+
+## Layout
+
+```text
+profiles/<name>/
+  cvm.profile.toml
+  portable/
+    instructions.md
+    skills/
+      <name>.md
+    agents/
+      <name>.md
+    settings.toml
+  claude/
+  codex/
+  opencode/
+```
+
+## Manifest
+
+```toml
+name = "lite"
+harnesses = ["claude", "opencode", "codex"]
+
+[assets]
+portable = "portable"
+claude = "claude"
+opencode = "opencode"
+codex = "codex"
+```
+
+If a harness-specific asset dir is omitted, `cvm` may use `[assets].portable` as the fallback. If neither is present, legacy profiles default to the profile root and `harnesses = ["claude"]`.
+
+## Merge Model
+
+Rendering order is:
+
+1. Load assets from `portable/`.
+2. Apply the target harness override dir, if present.
+3. Render or copy the final result into the target harness.
+
+Harness-specific assets win over portable assets for the same logical asset. `cvm` must not silently translate excluded assets; those belong in the harness override dir.
+
+## Lite Profile Status
+
+`profiles/lite` now declares this contract and extracts neutral instructions into `portable/instructions.md`. It still declares only `claude` support because the current skills, statusline, MCP config, and memory rules depend on Claude Code behavior. OpenCode and Codex support for `lite` should be enabled only after renderers can map portable instructions and skills into native formats without promising unsupported hooks, MCP, or memory behavior.

--- a/specs/portable-profiles.md
+++ b/specs/portable-profiles.md
@@ -1,8 +1,10 @@
-# Portable Profile Contract v1
+# Portable Profile Contract v0.1 Experimental
 
 ## Goal
 
 Define the small profile surface that `cvm` owns across harnesses. Portable assets are authored as `cvm` concepts first, then rendered or copied into Claude, OpenCode, Codex, or another harness when that harness has a compatible equivalent.
+
+This is an experimental v0.1 contract. The current implementation covers manifest parsing and portable asset-dir fallback only; renderer and merge-engine behavior is planned. Treat the layout as subject to tightening until at least one non-Claude renderer consumes it.
 
 ## Portable Rule
 
@@ -13,7 +15,9 @@ An asset is portable when all of these are true:
 - A missing or partial harness equivalent can be omitted or degraded explicitly.
 - The mapping is 1:1 or close to 1:1.
 
-If an asset requires semantic translation, behavior rewrites, or runtime-specific hooks, it is not portable v1.
+Portable v0.1 is exactly the included set below. Anything outside that set is harness-specific by default.
+
+If an asset requires semantic translation, behavior rewrites, or runtime-specific hooks, it is not portable v0.1.
 
 ## Included Assets
 
@@ -26,14 +30,21 @@ If an asset requires semantic translation, behavior rewrites, or runtime-specifi
 
 ## Excluded Assets
 
-These assets are harness-specific in portable v1:
+These assets are harness-specific in portable v0.1:
 
 - hooks
 - plugins
 - commands legacy
 - MCP config with incompatible formats
 - raw vendor settings files
+- statusline commands
+- keybindings
+- output styles
+- teams
+- path-scoped rules
 - runtime-specific memory, transcript, session, or cache data
+
+A skill is portable only when it avoids harness-specific subagent invocation, harness-specific filesystem paths, and cross-skill contracts that depend on harness state or output conventions. Skills that assume those behaviors must stay under `<harness>/skills/`.
 
 ## Layout
 
@@ -65,7 +76,7 @@ opencode = "opencode"
 codex = "codex"
 ```
 
-If a harness-specific asset dir is omitted, `cvm` may use `[assets].portable` as the fallback. If neither is present, legacy profiles default to the profile root and `harnesses = ["claude"]`.
+If a declared harness omits its harness-specific asset dir, `cvm` uses `[assets].portable` as the fallback. Profile authors are responsible for keeping that fallback directory limited to portable-shaped assets. If neither is present, legacy profiles default to the profile root and `harnesses = ["claude"]`.
 
 ## Merge Model
 
@@ -80,3 +91,5 @@ Harness-specific assets win over portable assets for the same logical asset. `cv
 ## Lite Profile Status
 
 `profiles/lite` now declares this contract and extracts neutral instructions into `portable/instructions.md`. It still declares only `claude` support because the current skills, statusline, MCP config, and memory rules depend on Claude Code behavior. OpenCode and Codex support for `lite` should be enabled only after renderers can map portable instructions and skills into native formats without promising unsupported hooks, MCP, or memory behavior.
+
+`lite` intentionally keeps Claude assets at the profile root with `claude = "."` for compatibility with the existing profile layout. New profiles may use the canonical sibling layout shown above when they do not need legacy root assets.


### PR DESCRIPTION
## Summary
- Define the portable profile v1 contract, layout, manifest shape, and exclusions.
- Add portable asset fallback support in manifest resolution with coverage.
- Annotate the lite profile with a manifest and neutral portable instructions while keeping it Claude-only for now.

## Tests
- go test ./...

Closes #38