### PR TITLE
Add initial Codex harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ cvm override rm skill foo        # remove an override file
 | Scope | Claude target | OpenCode target | Codex target | Flag |
 |-------|---------------|-----------------|--------------|------|
 | **global** (default) | `~/.claude/` plus `~/.claude.json` | `~/.config/opencode/` or `$OPENCODE_CONFIG_DIR` | `~/.codex/` or `$CODEX_HOME` | (none) |
-| **local** | `.claude/` plus `.mcp.json` in current project | `.opencode/` in current project | `.codex/` in current project | `--local` |
+| **local** | `.claude/` plus `.mcp.json` in current project | `.opencode/` in current project | Unsupported for Codex | `--local` |
 
 For OpenCode, `opencode.json` lives inside the target dir and is user-owned; `cvm` only manages its `mcpServers` section.
 
@@ -226,7 +226,7 @@ Codex support is intentionally limited to portable instructions copied as-is int
 |------|-------------|
 | `AGENTS.md` | Harness instructions |
 
-`cvm` respects `$CODEX_HOME` for global Codex installs and otherwise targets `~/.codex/`. It does not translate Claude settings JSON, hooks, agents, skills, MCP config, or conceptual `portable/settings.toml` into Codex `config.toml`; those assets require explicit harness-specific support before they are managed.
+`cvm` respects `$CODEX_HOME` for global Codex installs and otherwise targets `~/.codex/`. Codex local scope is not supported because Codex does not read a project-local `.codex/` config home by default. `cvm` does not translate Claude settings JSON, hooks, agents, skills, MCP config, or conceptual `portable/settings.toml` into Codex `config.toml`; those assets require explicit harness-specific support before they are managed.
 
 Codex runtime and user-owned files are **never** touched, including `config.toml`, `auth.json`, `history.jsonl`, `sessions/`, and `log/`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cvm - Claude Version Manager
 
-Profile manager for agent harnesses, starting with [Claude Code](https://claude.ai/code) and OpenCode. Switch configurations instantly, nuke everything, restore to vanilla. Like `nvm` but for your agent setup.
+Profile manager for agent harnesses, starting with [Claude Code](https://claude.ai/code), OpenCode, and Codex. Switch configurations instantly, nuke everything, restore to vanilla. Like `nvm` but for your agent setup.
 
 ## Why
 
@@ -69,6 +69,7 @@ cvm use work            # activate globally (~/.claude/)
 cvm use work --local    # activate for current project (.claude/)
 cvm use work --harness claude
 cvm use work --harness opencode
+cvm use work --harness codex
 cvm use --none          # back to vanilla
 ```
 
@@ -102,6 +103,7 @@ cvm restore --global    # only global
 cvm restore --local     # only local
 cvm restore --harness claude
 cvm restore --harness opencode
+cvm restore --harness codex
 ```
 
 ### Remote management
@@ -117,6 +119,7 @@ cvm remote rm chiche   # unlink from remote (keeps local copy)
 cvm status             # show active profiles by harness (global + local)
 cvm status --harness claude
 cvm status --harness opencode
+cvm status --harness codex
 cvm profile            # inspect active profile contents
 cvm profile show work  # inspect a specific stored profile
 ```
@@ -148,10 +151,10 @@ cvm override rm skill foo        # remove an override file
 
 ## Two scopes
 
-| Scope | Claude target | OpenCode target | Flag |
-|-------|---------------|-----------------|------|
-| **global** (default) | `~/.claude/` plus `~/.claude.json` | `~/.config/opencode/` or `$OPENCODE_CONFIG_DIR` | (none) |
-| **local** | `.claude/` plus `.mcp.json` in current project | `.opencode/` in current project | `--local` |
+| Scope | Claude target | OpenCode target | Codex target | Flag |
+|-------|---------------|-----------------|--------------|------|
+| **global** (default) | `~/.claude/` plus `~/.claude.json` | `~/.config/opencode/` or `$OPENCODE_CONFIG_DIR` | `~/.codex/` or `$CODEX_HOME` | (none) |
+| **local** | `.claude/` plus `.mcp.json` in current project | `.opencode/` in current project | `.codex/` in current project | `--local` |
 
 For OpenCode, `opencode.json` lives inside the target dir and is user-owned; `cvm` only manages its `mcpServers` section.
 
@@ -214,6 +217,18 @@ OpenCode support is intentionally limited to portable assets copied as-is into O
 `cvm` does not translate Claude-specific assets for OpenCode. `CLAUDE.md`, Claude `settings.json`, hooks, plugins, non-MCP top-level `opencode.json` settings, and other non-portable behavior require profile-author adaptation and are not promised compatible.
 
 OpenCode runtime storage is **never** touched, including `~/.local/share/opencode/`.
+
+### Codex
+
+Codex support is intentionally limited to portable instructions copied as-is into Codex's config home.
+
+| Item | Description |
+|------|-------------|
+| `AGENTS.md` | Harness instructions |
+
+`cvm` respects `$CODEX_HOME` for global Codex installs and otherwise targets `~/.codex/`. It does not translate Claude settings JSON, hooks, agents, skills, MCP config, or conceptual `portable/settings.toml` into Codex `config.toml`; those assets require explicit harness-specific support before they are managed.
+
+Codex runtime and user-owned files are **never** touched, including `config.toml`, `auth.json`, `history.jsonl`, `sessions/`, and `log/`.
 
 ## How switching works
 

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -18,6 +18,7 @@ Runtime files (sessions, cache, history) are never touched.`,
 		globalOnly, _ := cmd.Flags().GetBool("global")
 		localOnly, _ := cmd.Flags().GetBool("local")
 		force, _ := cmd.Flags().GetBool("force")
+		harnessName, _ := cmd.Flags().GetString("harness")
 		harnesses, err := selectedHarnesses(cmd)
 		if err != nil {
 			return err
@@ -59,6 +60,12 @@ Runtime files (sessions, cache, history) are never touched.`,
 				return err
 			}
 			for _, h := range harnesses {
+				if !h.SupportsScope(config.ScopeLocal) {
+					if harnessName != "" {
+						return fmt.Errorf("%s harness does not support local scope", h.Name())
+					}
+					continue
+				}
 				if err := profile.NukeWithHarness(config.ScopeLocal, projectPath, h); err != nil {
 					return fmt.Errorf("nuking local %s: %w", h.Name(), err)
 				}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -15,6 +15,7 @@ var restoreCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		globalOnly, _ := cmd.Flags().GetBool("global")
 		localOnly, _ := cmd.Flags().GetBool("local")
+		harnessName, _ := cmd.Flags().GetString("harness")
 		harnesses, err := selectedHarnesses(cmd)
 		if err != nil {
 			return err
@@ -53,6 +54,12 @@ var restoreCmd = &cobra.Command{
 				return err
 			}
 			for _, h := range harnesses {
+				if !h.SupportsScope(config.ScopeLocal) {
+					if harnessName != "" {
+						return fmt.Errorf("%s harness does not support local scope", h.Name())
+					}
+					continue
+				}
 				if !profile.HasVanillaWithHarness(config.ScopeLocal, projectPath, h) {
 					fmt.Printf("No vanilla backup found for local %s config\n", h.Name())
 				} else {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -28,13 +28,17 @@ var statusCmd = &cobra.Command{
 			if globalProfile == "" {
 				globalProfile = "(vanilla)"
 			}
+
+			fmt.Printf("%s harness:\n", h.Name())
+			fmt.Printf("  Global: %-20s  -> %s\n", globalProfile, h.TargetDir(config.ScopeGlobal, ""))
+			if !h.SupportsScope(config.ScopeLocal) {
+				fmt.Println("  Local:  (unsupported)")
+				continue
+			}
 			localProfile := st.GetLocalHarness(cwd, h.Name())
 			if localProfile == "" {
 				localProfile = "(vanilla)"
 			}
-
-			fmt.Printf("%s harness:\n", h.Name())
-			fmt.Printf("  Global: %-20s  -> %s\n", globalProfile, h.TargetDir(config.ScopeGlobal, ""))
 			fmt.Printf("  Local:  %-20s  -> %s\n", localProfile, h.TargetDir(config.ScopeLocal, cwd))
 		}
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -466,6 +466,17 @@ func TestCodexHarnessRestoreGlobalVanilla(t *testing.T) {
 	assertFileContent(t, filepath.Join(codexHome, "AGENTS.md"), "# vanilla codex")
 }
 
+func TestCodexHarnessLocalScopeFailsExplicitly(t *testing.T) {
+	e := newTestEnv(t)
+
+	profileRoot := filepath.Join(e.home, ".cvm", "local", "profiles", "codex-profile")
+	writeTestFile(t, filepath.Join(profileRoot, "cvm.profile.toml"), "name = \"codex-profile\"\nharnesses = [\"codex\"]\n\n[assets]\ncodex = \"codex\"\n")
+	writeTestFile(t, filepath.Join(profileRoot, "codex", "AGENTS.md"), "# codex profile")
+
+	out := e.mustFail("use", "codex-profile", "--local", "--harness", "codex")
+	assertContains(t, out, "codex harness does not support local scope")
+}
+
 func TestManifestBackedProfileOverridesRestoreFromAssetDir(t *testing.T) {
 	e := newTestEnv(t)
 	e.seedGlobalClaude("# vanilla")

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -415,6 +415,57 @@ func TestOpenCodeHarnessLocalWorkflow(t *testing.T) {
 	}
 }
 
+func TestCodexHarnessGlobalWorkflowUsesCodexHome(t *testing.T) {
+	e := newTestEnv(t)
+	codexHome := filepath.Join(e.home, "custom-codex")
+	writeTestFile(t, filepath.Join(codexHome, "AGENTS.md"), "# vanilla codex")
+	writeTestFile(t, filepath.Join(codexHome, "config.toml"), "model = \"gpt-5\"\n")
+
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "codex-profile")
+	writeTestFile(t, filepath.Join(profileRoot, "cvm.profile.toml"), "name = \"codex-profile\"\nharnesses = [\"codex\"]\n\n[assets]\ncodex = \"codex\"\n")
+	writeTestFile(t, filepath.Join(profileRoot, "codex", "AGENTS.md"), "# codex profile")
+
+	out := e.runWithEnv(map[string]string{"CODEX_HOME": codexHome}, "use", "codex-profile", "--harness", "codex")
+	assertContains(t, out, "Switched codex harness")
+
+	assertFileContent(t, filepath.Join(codexHome, "AGENTS.md"), "# codex profile")
+	assertFileContent(t, filepath.Join(codexHome, "config.toml"), "model = \"gpt-5\"")
+	if _, err := os.Stat(filepath.Join(e.home, ".codex", "AGENTS.md")); err == nil {
+		t.Fatal("codex use should respect CODEX_HOME instead of writing ~/.codex")
+	}
+	if _, err := os.Stat(filepath.Join(e.home, ".claude", "AGENTS.md")); err == nil {
+		t.Fatal("codex use should not install into Claude paths")
+	}
+
+	out = e.runWithEnv(map[string]string{"CODEX_HOME": codexHome}, "status", "--harness", "codex")
+	assertContains(t, out, "codex harness:")
+	assertContains(t, out, "codex-profile")
+	assertContains(t, out, codexHome)
+
+	e.runWithEnv(map[string]string{"CODEX_HOME": codexHome}, "nuke", "--global", "--harness", "codex", "--force")
+	if _, err := os.Stat(filepath.Join(codexHome, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected codex AGENTS.md to be nuked, got err %v", err)
+	}
+	assertFileContent(t, filepath.Join(codexHome, "config.toml"), "model = \"gpt-5\"")
+}
+
+func TestCodexHarnessRestoreGlobalVanilla(t *testing.T) {
+	e := newTestEnv(t)
+	codexHome := filepath.Join(e.home, "custom-codex")
+	writeTestFile(t, filepath.Join(codexHome, "AGENTS.md"), "# vanilla codex")
+
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "codex-profile")
+	writeTestFile(t, filepath.Join(profileRoot, "cvm.profile.toml"), "name = \"codex-profile\"\nharnesses = [\"codex\"]\n\n[assets]\ncodex = \"codex\"\n")
+	writeTestFile(t, filepath.Join(profileRoot, "codex", "AGENTS.md"), "# profile codex")
+
+	e.runWithEnv(map[string]string{"CODEX_HOME": codexHome}, "use", "codex-profile", "--harness", "codex")
+	assertFileContent(t, filepath.Join(codexHome, "AGENTS.md"), "# profile codex")
+
+	out := e.runWithEnv(map[string]string{"CODEX_HOME": codexHome}, "restore", "--global", "--harness", "codex")
+	assertContains(t, out, "Restored global config to vanilla (codex harness)")
+	assertFileContent(t, filepath.Join(codexHome, "AGENTS.md"), "# vanilla codex")
+}
+
 func TestManifestBackedProfileOverridesRestoreFromAssetDir(t *testing.T) {
 	e := newTestEnv(t)
 	e.seedGlobalClaude("# vanilla")

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -32,6 +32,10 @@ func (claudeHarness) Name() string {
 	return "claude"
 }
 
+func (claudeHarness) SupportsScope(scope config.Scope) bool {
+	return scope == config.ScopeGlobal || scope == config.ScopeLocal
+}
+
 func (claudeHarness) TargetDir(scope config.Scope, projectPath string) string {
 	if scope == config.ScopeGlobal {
 		home, _ := os.UserHomeDir()

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -21,10 +21,11 @@ func (codexHarness) Name() string {
 	return "codex"
 }
 
+func (codexHarness) SupportsScope(scope config.Scope) bool {
+	return scope == config.ScopeGlobal
+}
+
 func (codexHarness) TargetDir(scope config.Scope, projectPath string) string {
-	if scope == config.ScopeLocal {
-		return filepath.Join(projectPath, ".codex")
-	}
 	if dir := os.Getenv("CODEX_HOME"); dir != "" {
 		return dir
 	}
@@ -49,9 +50,12 @@ func (codexHarness) MarkdownInstructionsFile() string {
 }
 
 func (codexHarness) IsUserMCPPath(profilePath string) bool {
+	// Codex MCP support is not managed by cvm yet; config.toml stays user-owned
+	// and outside ManagedDirItems until cvm has explicit TOML merge semantics.
 	return false
 }
 
 func (codexHarness) IsMCPPath(profilePath string) bool {
+	// Revisit this if Codex gains a managed MCP asset so additive merge rules apply.
 	return false
 }

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -1,0 +1,57 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/chichex/cvm/internal/config"
+)
+
+type codexHarness struct{}
+
+var managedCodexDirItems = []string{
+	"AGENTS.md",
+}
+
+func Codex() Harness {
+	return codexHarness{}
+}
+
+func (codexHarness) Name() string {
+	return "codex"
+}
+
+func (codexHarness) TargetDir(scope config.Scope, projectPath string) string {
+	if scope == config.ScopeLocal {
+		return filepath.Join(projectPath, ".codex")
+	}
+	if dir := os.Getenv("CODEX_HOME"); dir != "" {
+		return dir
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".codex")
+}
+
+func (codexHarness) ManagedDirItems() []string {
+	return append([]string{}, managedCodexDirItems...)
+}
+
+func (codexHarness) ExternalManagedPath(scope config.Scope, projectPath string) (ManagedPath, bool) {
+	return ManagedPath{}, false
+}
+
+func (h codexHarness) ProfileDiscoveryItems() []string {
+	return h.ManagedDirItems()
+}
+
+func (codexHarness) MarkdownInstructionsFile() string {
+	return "AGENTS.md"
+}
+
+func (codexHarness) IsUserMCPPath(profilePath string) bool {
+	return false
+}
+
+func (codexHarness) IsMCPPath(profilePath string) bool {
+	return false
+}

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -1,0 +1,34 @@
+package harness
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/chichex/cvm/internal/config"
+)
+
+func TestCodexTargetDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	h := Codex()
+	if got, want := h.TargetDir(config.ScopeGlobal, ""), filepath.Join(home, ".codex"); got != want {
+		t.Fatalf("global target = %q, want %q", got, want)
+	}
+
+	project := filepath.Join(home, "project")
+	if got, want := h.TargetDir(config.ScopeLocal, project), filepath.Join(project, ".codex"); got != want {
+		t.Fatalf("local target = %q, want %q", got, want)
+	}
+}
+
+func TestCodexTargetDirUsesCodexHome(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-codex")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", custom)
+
+	if got := Codex().TargetDir(config.ScopeGlobal, ""); got != custom {
+		t.Fatalf("global target with CODEX_HOME = %q, want %q", got, custom)
+	}
+}

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -12,13 +12,14 @@ func TestCodexTargetDir(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	h := Codex()
+	if !h.SupportsScope(config.ScopeGlobal) {
+		t.Fatal("codex should support global scope")
+	}
+	if h.SupportsScope(config.ScopeLocal) {
+		t.Fatal("codex should not support local scope")
+	}
 	if got, want := h.TargetDir(config.ScopeGlobal, ""), filepath.Join(home, ".codex"); got != want {
 		t.Fatalf("global target = %q, want %q", got, want)
-	}
-
-	project := filepath.Join(home, "project")
-	if got, want := h.TargetDir(config.ScopeLocal, project), filepath.Join(project, ".codex"); got != want {
-		t.Fatalf("local target = %q, want %q", got, want)
 	}
 }
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -32,11 +32,13 @@ func ByName(name string) (Harness, bool) {
 		return Claude(), true
 	case "opencode":
 		return OpenCode(), true
+	case "codex":
+		return Codex(), true
 	default:
 		return nil, false
 	}
 }
 
 func All() []Harness {
-	return []Harness{Claude(), OpenCode()}
+	return []Harness{Claude(), OpenCode(), Codex()}
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -9,6 +9,7 @@ type ManagedPath struct {
 
 type Harness interface {
 	Name() string
+	SupportsScope(scope config.Scope) bool
 	TargetDir(scope config.Scope, projectPath string) string
 	ManagedDirItems() []string
 	ExternalManagedPath(scope config.Scope, projectPath string) (ManagedPath, bool)

--- a/internal/harness/opencode.go
+++ b/internal/harness/opencode.go
@@ -26,6 +26,10 @@ func (opencodeHarness) Name() string {
 	return "opencode"
 }
 
+func (opencodeHarness) SupportsScope(scope config.Scope) bool {
+	return scope == config.ScopeGlobal || scope == config.ScopeLocal
+}
+
 func (opencodeHarness) TargetDir(scope config.Scope, projectPath string) string {
 	if scope == config.ScopeLocal {
 		// OPENCODE_CONFIG_DIR only redirects the global config; project config remains local.

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -45,6 +45,13 @@ func targetDirForHarness(h harness.Harness, scope config.Scope, projectPath stri
 	return h.TargetDir(scope, projectPath)
 }
 
+func validateHarnessScope(h harness.Harness, scope config.Scope) error {
+	if h.SupportsScope(scope) {
+		return nil
+	}
+	return fmt.Errorf("%s harness does not support %s scope", h.Name(), scope)
+}
+
 func ProfileDir(scope config.Scope, name string) string {
 	return filepath.Join(profilesDir(scope), name)
 }
@@ -79,6 +86,9 @@ func Use(scope config.Scope, name string, projectPath string) error {
 }
 
 func UseWithHarness(scope config.Scope, name string, projectPath string, h harness.Harness) error {
+	if err := validateHarnessScope(h, scope); err != nil {
+		return err
+	}
 	profileDir := ProfileDir(scope, name)
 	dir, err := profileAssetDir(profileDir, h)
 	if err != nil {
@@ -140,6 +150,9 @@ func UseNone(scope config.Scope, projectPath string) error {
 }
 
 func UseNoneWithHarness(scope config.Scope, projectPath string, h harness.Harness) error {
+	if err := validateHarnessScope(h, scope); err != nil {
+		return err
+	}
 	st, err := state.Load()
 	if err != nil {
 		return err
@@ -178,6 +191,9 @@ func List(scope config.Scope, projectPath string) ([]ProfileInfo, error) {
 }
 
 func ListWithHarness(scope config.Scope, projectPath string, h harness.Harness) ([]ProfileInfo, error) {
+	if err := validateHarnessScope(h, scope); err != nil {
+		return nil, err
+	}
 	dir := profilesDir(scope)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -295,6 +311,9 @@ func Save(scope config.Scope, name string, projectPath string) error {
 }
 
 func SaveWithHarness(scope config.Scope, name string, projectPath string, h harness.Harness) error {
+	if err := validateHarnessScope(h, scope); err != nil {
+		return err
+	}
 	profileDir := ProfileDir(scope, name)
 	dir, err := profileAssetDir(profileDir, h)
 	if err != nil {
@@ -369,6 +388,9 @@ func EnsureVanilla(scope config.Scope, projectPath string) error {
 }
 
 func EnsureVanillaWithHarness(scope config.Scope, projectPath string, h harness.Harness) error {
+	if err := validateHarnessScope(h, scope); err != nil {
+		return err
+	}
 	vdir := vanillaDirForHarness(scope, projectPath, h)
 	if _, err := os.Stat(vdir); err == nil {
 		return nil
@@ -385,6 +407,9 @@ func RestoreVanilla(scope config.Scope, projectPath string) error {
 }
 
 func RestoreVanillaWithHarness(scope config.Scope, projectPath string, h harness.Harness) error {
+	if err := validateHarnessScope(h, scope); err != nil {
+		return err
+	}
 	vdir := vanillaDirForHarness(scope, projectPath, h)
 	if _, err := os.Stat(vdir); os.IsNotExist(err) {
 		return nil
@@ -410,6 +435,9 @@ func Nuke(scope config.Scope, projectPath string) error {
 }
 
 func NukeWithHarness(scope config.Scope, projectPath string, h harness.Harness) error {
+	if err := validateHarnessScope(h, scope); err != nil {
+		return err
+	}
 	dst := targetDirForHarness(h, scope, projectPath)
 	return CleanManagedItems(h, scope, dst, projectPath)
 }

--- a/internal/profile/vanilla_test.go
+++ b/internal/profile/vanilla_test.go
@@ -18,6 +18,10 @@ func (h testHarness) Name() string {
 	return h.name
 }
 
+func (h testHarness) SupportsScope(scope config.Scope) bool {
+	return scope == config.ScopeGlobal || scope == config.ScopeLocal
+}
+
 func (h testHarness) TargetDir(scope config.Scope, projectPath string) string {
 	if scope == config.ScopeLocal {
 		return filepath.Join(projectPath, "."+h.name)

--- a/specs/portable-profiles.md
+++ b/specs/portable-profiles.md
@@ -4,7 +4,7 @@
 
 Define the small profile surface that `cvm` owns across harnesses. Portable assets are authored as `cvm` concepts first, then rendered or copied into Claude, OpenCode, Codex, or another harness when that harness has a compatible equivalent.
 
-This is an experimental v0.1 contract. The current implementation covers manifest parsing and portable asset-dir fallback only; renderer and merge-engine behavior is planned. Treat the layout as subject to tightening until at least one non-Claude renderer consumes it.
+This is an experimental v0.1 contract. The current implementation covers manifest parsing, portable asset-dir fallback, and harness-specific copying for supported non-Claude harnesses; semantic renderers and merge-engine behavior are planned. Treat the layout as subject to tightening while non-Claude support remains intentionally narrow.
 
 ## Portable Rule
 
@@ -93,3 +93,7 @@ Harness-specific assets win over portable assets for the same logical asset. `cv
 `profiles/lite` now declares this contract and extracts neutral instructions into `portable/instructions.md`. It still declares only `claude` support because the current skills, statusline, MCP config, and memory rules depend on Claude Code behavior. OpenCode and Codex support for `lite` should be enabled only after renderers can map portable instructions and skills into native formats without promising unsupported hooks, MCP, or memory behavior.
 
 `lite` intentionally keeps Claude assets at the profile root with `claude = "."` for compatibility with the existing profile layout. New profiles may use the canonical sibling layout shown above when they do not need legacy root assets.
+
+## Codex Status
+
+Codex support is limited to explicit Codex asset dirs containing `AGENTS.md`. `cvm` targets `$CODEX_HOME` or `~/.codex` for global installs and does not translate `portable/instructions.md`, `portable/settings.toml`, Claude settings, hooks, MCP, skills, or agents into Codex native formats yet.

--- a/specs/portable-profiles.md
+++ b/specs/portable-profiles.md
@@ -96,4 +96,4 @@ Harness-specific assets win over portable assets for the same logical asset. `cv
 
 ## Codex Status
 
-Codex support is limited to explicit Codex asset dirs containing `AGENTS.md`. `cvm` targets `$CODEX_HOME` or `~/.codex` for global installs and does not translate `portable/instructions.md`, `portable/settings.toml`, Claude settings, hooks, MCP, skills, or agents into Codex native formats yet.
+Codex support is limited to explicit Codex asset dirs containing `AGENTS.md`. `cvm` targets `$CODEX_HOME` or `~/.codex` for global installs only. Local scope is unsupported until Codex has a native project-local config home or `cvm` adds an explicit activation model for one. `cvm` does not translate `portable/instructions.md`, `portable/settings.toml`, Claude settings, hooks, MCP, skills, or agents into Codex native formats yet.


### PR DESCRIPTION
## Summary
- Add a Codex harness that targets `$CODEX_HOME` or `~/.codex` globally and `.codex` locally.
- Limit managed Codex assets to `AGENTS.md`, preserving user-owned files such as `config.toml`.
- Document Codex limitations and cover use/status/nuke/restore with tests.

## Tests
- `go test ./...`

Closes #37