### PR TITLE
Add profile asset authoring commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ When adding from a repo without a path, cvm auto-discovers the profile:
 3. If the repo root is a profile, uses that
 4. If multiple profiles found, lists them for you to pick
 
+### Author profile assets
+
+```bash
+cvm profile add instructions --profile work
+cvm profile add skill deploy --profile work
+cvm profile add agent reviewer --profile work
+cvm profile add hook post --profile work --harness claude
+cvm profile add skill deploy --profile work --harness opencode --from-file ./deploy.md
+```
+
+By default, `instructions`, `skill`, and `agent` are portable assets written under `portable/`. Passing `--harness` writes a harness-specific asset under that harness directory. Hooks are always harness-specific and require `--harness`.
+
 ### Switch profiles
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ cvm profile add hook post --profile work --harness claude
 cvm profile add skill deploy --profile work --harness opencode --from-file ./deploy.md
 ```
 
-By default, `instructions`, `skill`, and `agent` are portable assets written under `portable/`. Passing `--harness` writes a harness-specific asset under that harness directory. Hooks are always harness-specific and require `--harness`.
+By default, `instructions`, `skill`, and `agent` are portable authoring assets written under `portable/`. Portable assets are inputs for the portable contract; harness rendering is planned separately, so use `--harness` when you need an asset applied by today's activation flow. Passing `--harness` writes a harness-specific asset under that harness directory. Hooks are always harness-specific and require `--harness`.
+
+Use `cvm profile add` to author the base profile. Use `cvm override add` for personal customizations layered on top of an active profile.
 
 ### Switch profiles
 

--- a/cmd/override.go
+++ b/cmd/override.go
@@ -49,12 +49,20 @@ func overrideScope(cmd *cobra.Command) (config.Scope, string, string, error) {
 }
 
 func openEditor(path string) error {
+	return openEditorWithFallback(path, "Override path")
+}
+
+func openAssetEditor(path string) error {
+	return openEditorWithFallback(path, "Asset path")
+}
+
+func openEditorWithFallback(path, fallbackLabel string) error {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		editor = os.Getenv("VISUAL")
 	}
 	if editor == "" {
-		fmt.Printf("Override path: %s\n", path)
+		fmt.Printf("%s: %s\n", fallbackLabel, path)
 		return nil
 	}
 	cmd := exec.Command("sh", "-c", editor+" "+shellQuote(path))

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -84,7 +85,11 @@ var profileAddCmd = &cobra.Command{
 
 Portable assets are cvm-owned concepts written under portable/: instructions,
 skills, and agents. Passing --harness writes a harness-specific override instead.
-Hooks are always harness-specific and require --harness.`,
+Hooks are always harness-specific and require --harness.
+
+Portable assets are authoring inputs for the portable contract. Harness rendering
+is planned separately, so use --harness when you need an asset applied by today's
+activation flow.`,
 	Example: `  cvm profile add instructions --profile work
   cvm profile add skill deploy --profile work
   cvm profile add agent reviewer --profile work
@@ -142,6 +147,12 @@ Hooks are always harness-specific and require --harness.`,
 			fmt.Printf("Created %s %s: %s\n", asset.Layer, asset.Kind, asset.Path)
 		} else {
 			fmt.Printf("Profile asset already exists: %s\n", asset.Path)
+		}
+		if asset.ManifestCreated {
+			fmt.Printf("Created manifest: %s\n", filepath.Join(profile.ProfileDir(scope, profileName), "cvm.profile.toml"))
+		}
+		if asset.Portable {
+			fmt.Println("Note: portable assets are authored now; harness rendering is planned separately.")
 		}
 		if open {
 			return openAssetEditor(asset.Path)

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -13,7 +13,7 @@ import (
 
 var profileCmd = &cobra.Command{
 	Use:   "profile",
-	Short: "Inspect active profile contents",
+	Short: "Inspect and author profile contents",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -77,10 +77,108 @@ var profileShowCmd = &cobra.Command{
 	},
 }
 
+var profileAddCmd = &cobra.Command{
+	Use:   "add <skill|hook|agent|instructions> [name]",
+	Short: "Scaffold a profile asset",
+	Long: `Scaffold profile assets without editing cvm's internal layout directly.
+
+Portable assets are cvm-owned concepts written under portable/: instructions,
+skills, and agents. Passing --harness writes a harness-specific override instead.
+Hooks are always harness-specific and require --harness.`,
+	Example: `  cvm profile add instructions --profile work
+  cvm profile add skill deploy --profile work
+  cvm profile add agent reviewer --profile work
+  cvm profile add hook post --profile work --harness claude
+  cvm profile add skill deploy --profile work --harness opencode --from-file ./deploy.md`,
+	Args: validateProfileAddArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		isLocal, _ := cmd.Flags().GetBool("local")
+		scope := config.ScopeGlobal
+		projectPath := ""
+		if isLocal {
+			scope = config.ScopeLocal
+			var err error
+			projectPath, err = getProjectPath()
+			if err != nil {
+				return err
+			}
+		}
+
+		profileName, _ := cmd.Flags().GetString("profile")
+		if profileName == "" {
+			current, err := profile.Current(scope, projectPath)
+			if err != nil {
+				return err
+			}
+			if current == "" {
+				return fmt.Errorf("no active %s profile; pass --profile <name>", scope)
+			}
+			profileName = current
+		}
+
+		harnessName, _ := cmd.Flags().GetString("harness")
+		fromFile, _ := cmd.Flags().GetString("from-file")
+		open, _ := cmd.Flags().GetBool("open")
+
+		name := ""
+		if len(args) > 1 {
+			name = args[1]
+		}
+
+		asset, err := profile.ScaffoldAsset(profile.ScaffoldAssetOptions{
+			Scope:       scope,
+			ProfileName: profileName,
+			ProjectPath: projectPath,
+			Kind:        args[0],
+			Name:        name,
+			HarnessName: harnessName,
+			FromFile:    fromFile,
+		})
+		if err != nil {
+			return err
+		}
+
+		if asset.Created {
+			fmt.Printf("Created %s %s: %s\n", asset.Layer, asset.Kind, asset.Path)
+		} else {
+			fmt.Printf("Profile asset already exists: %s\n", asset.Path)
+		}
+		if open {
+			return openAssetEditor(asset.Path)
+		}
+		return nil
+	},
+}
+
 func init() {
+	profileAddCmd.Flags().String("profile", "", "Profile to edit (default: active profile in selected scope)")
+	profileAddCmd.Flags().Bool("local", false, "Edit a local profile (default: global)")
+	profileAddCmd.Flags().String("harness", "", "Write a harness-specific asset instead of a portable asset")
+	profileAddCmd.Flags().String("from-file", "", "Seed the asset from an existing file")
+	profileAddCmd.Flags().Bool("open", false, "Open the scaffolded asset in $EDITOR")
 	profileShowCmd.Flags().Bool("local", false, "Inspect a local profile (default: global)")
+	profileCmd.AddCommand(profileAddCmd)
 	profileCmd.AddCommand(profileShowCmd)
 	rootCmd.AddCommand(profileCmd)
+}
+
+func validateProfileAddArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("provide an asset type: skill, hook, agent, or instructions")
+	}
+	switch args[0] {
+	case "instructions":
+		if len(args) != 1 {
+			return fmt.Errorf("instructions does not take a name")
+		}
+	case "skill", "hook", "agent":
+		if len(args) != 2 {
+			return fmt.Errorf("%s requires a name", args[0])
+		}
+	default:
+		return fmt.Errorf("unknown type %q: must be one of skill, hook, agent, instructions", args[0])
+	}
+	return nil
 }
 
 func printInventory(scope config.Scope, name, projectPath string) error {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -529,7 +529,6 @@ func TestProfileAddScaffoldsPortableAssets(t *testing.T) {
 	assertFileContains(t, filepath.Join(profileRoot, "portable", "instructions.md"), "# Profile Instructions")
 	assertFileContains(t, filepath.Join(profileRoot, "opencode", "AGENTS.md"), "# Profile Instructions")
 	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "portable = \"portable\"")
-	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "claude = \"claude\"")
 	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "opencode = \"opencode\"")
 }
 
@@ -595,7 +594,9 @@ func TestProfileAddDefaultsToActiveProfile(t *testing.T) {
 	out := e.mustRun("profile", "add", "instructions")
 	assertContains(t, out, "Created portable instructions")
 
-	assertFileContains(t, filepath.Join(e.home, ".cvm", "global", "profiles", "active", "portable", "instructions.md"), "# Profile Instructions")
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "active")
+	assertFileContains(t, filepath.Join(profileRoot, "portable", "instructions.md"), "# Profile Instructions")
+	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "claude = \".\"")
 }
 
 func TestProfileAddHelpExplainsAuthoringLayers(t *testing.T) {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -514,6 +514,8 @@ func TestProfileAddScaffoldsPortableAssets(t *testing.T) {
 
 	out := e.mustRun("profile", "add", "skill", "deploy", "--profile", "portable")
 	assertContains(t, out, "Created portable skill")
+	assertContains(t, out, "Created manifest:")
+	assertContains(t, out, "portable assets are authored now")
 	out = e.mustRun("profile", "add", "agent", "reviewer", "--profile", "portable")
 	assertContains(t, out, "Created portable agent")
 	out = e.mustRun("profile", "add", "instructions", "--profile", "portable")
@@ -549,6 +551,40 @@ func TestProfileAddScaffoldsHarnessSpecificHookFromFile(t *testing.T) {
 	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "claude = \"claude\"")
 }
 
+func TestProfileAddRejectsInvalidHarnessAndSource(t *testing.T) {
+	e := newTestEnv(t)
+
+	e.mustRun("add", "invalid")
+
+	out := e.mustFail("profile", "add", "skill", "deploy", "--profile", "invalid", "--harness", "missing")
+	assertContains(t, out, "unknown harness")
+
+	sourceDir := filepath.Join(e.projectDir, "source-dir")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	out = e.mustFail("profile", "add", "skill", "deploy", "--profile", "invalid", "--from-file", sourceDir)
+	assertContains(t, out, "is a directory")
+
+	out = e.mustFail("profile", "add", "hook", "post", "--profile", "invalid", "--harness", "opencode")
+	assertContains(t, out, "opencode does not support hook scaffolding")
+}
+
+func TestProfileAddDoesNotOverwriteExistingAsset(t *testing.T) {
+	e := newTestEnv(t)
+
+	e.mustRun("add", "existing")
+	source := filepath.Join(e.projectDir, "deploy.md")
+	writeTestFile(t, source, "first")
+	e.mustRun("profile", "add", "skill", "deploy", "--profile", "existing", "--from-file", source)
+
+	writeTestFile(t, source, "second")
+	out := e.mustRun("profile", "add", "skill", "deploy", "--profile", "existing", "--from-file", source)
+	assertContains(t, out, "Profile asset already exists")
+
+	assertFileContent(t, filepath.Join(e.home, ".cvm", "global", "profiles", "existing", "portable", "skills", "deploy.md"), "first")
+}
+
 func TestProfileAddDefaultsToActiveProfile(t *testing.T) {
 	e := newTestEnv(t)
 	e.seedGlobalClaude("# vanilla")
@@ -568,6 +604,7 @@ func TestProfileAddHelpExplainsAuthoringLayers(t *testing.T) {
 	out := e.mustRun("profile", "add", "--help")
 	assertContains(t, out, "Portable assets")
 	assertContains(t, out, "Hooks are always harness-specific")
+	assertContains(t, out, "Harness rendering")
 }
 
 func TestLsShowsInUseProfiles(t *testing.T) {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -507,6 +507,69 @@ func TestProfileInspect(t *testing.T) {
 	assertContains(t, out, "Rules (1): scope.md")
 }
 
+func TestProfileAddScaffoldsPortableAssets(t *testing.T) {
+	e := newTestEnv(t)
+
+	e.mustRun("add", "portable")
+
+	out := e.mustRun("profile", "add", "skill", "deploy", "--profile", "portable")
+	assertContains(t, out, "Created portable skill")
+	out = e.mustRun("profile", "add", "agent", "reviewer", "--profile", "portable")
+	assertContains(t, out, "Created portable agent")
+	out = e.mustRun("profile", "add", "instructions", "--profile", "portable")
+	assertContains(t, out, "Created portable instructions")
+	out = e.mustRun("profile", "add", "instructions", "--profile", "portable", "--harness", "opencode")
+	assertContains(t, out, "Created opencode instructions")
+
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "portable")
+	assertFileContains(t, filepath.Join(profileRoot, "portable", "skills", "deploy.md"), "description:")
+	assertFileContains(t, filepath.Join(profileRoot, "portable", "agents", "reviewer.md"), "# reviewer")
+	assertFileContains(t, filepath.Join(profileRoot, "portable", "instructions.md"), "# Profile Instructions")
+	assertFileContains(t, filepath.Join(profileRoot, "opencode", "AGENTS.md"), "# Profile Instructions")
+	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "portable = \"portable\"")
+	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "claude = \"claude\"")
+	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "opencode = \"opencode\"")
+}
+
+func TestProfileAddScaffoldsHarnessSpecificHookFromFile(t *testing.T) {
+	e := newTestEnv(t)
+
+	e.mustRun("add", "hooks")
+
+	out := e.mustFail("profile", "add", "hook", "post", "--profile", "hooks")
+	assertContains(t, out, "--harness")
+
+	source := filepath.Join(e.projectDir, "post.sh")
+	writeTestFile(t, source, "#!/bin/sh\nexit 0\n")
+	out = e.mustRun("profile", "add", "hook", "post", "--profile", "hooks", "--harness", "claude", "--from-file", source)
+	assertContains(t, out, "Created claude hook")
+
+	profileRoot := filepath.Join(e.home, ".cvm", "global", "profiles", "hooks")
+	assertFileContent(t, filepath.Join(profileRoot, "claude", "hooks", "post.sh"), "#!/bin/sh\nexit 0")
+	assertFileContains(t, filepath.Join(profileRoot, "cvm.profile.toml"), "claude = \"claude\"")
+}
+
+func TestProfileAddDefaultsToActiveProfile(t *testing.T) {
+	e := newTestEnv(t)
+	e.seedGlobalClaude("# vanilla")
+
+	e.mustRun("add", "active")
+	e.mustRun("use", "active")
+
+	out := e.mustRun("profile", "add", "instructions")
+	assertContains(t, out, "Created portable instructions")
+
+	assertFileContains(t, filepath.Join(e.home, ".cvm", "global", "profiles", "active", "portable", "instructions.md"), "# Profile Instructions")
+}
+
+func TestProfileAddHelpExplainsAuthoringLayers(t *testing.T) {
+	e := newTestEnv(t)
+
+	out := e.mustRun("profile", "add", "--help")
+	assertContains(t, out, "Portable assets")
+	assertContains(t, out, "Hooks are always harness-specific")
+}
+
 func TestLsShowsInUseProfiles(t *testing.T) {
 	e := newTestEnv(t)
 	e.seedGlobalClaude("# vanilla")
@@ -1062,6 +1125,18 @@ func assertFileContent(t *testing.T, path, want string) {
 	}
 	if strings.TrimSpace(string(data)) != want {
 		t.Fatalf("%s content = %q, want %q", path, strings.TrimSpace(string(data)), want)
+	}
+}
+
+func assertFileContains(t *testing.T, path, want string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("%s content should contain %q, got %q", path, want, string(data))
 	}
 }
 

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -38,6 +39,30 @@ func (claudeHarness) TargetDir(scope config.Scope, projectPath string) string {
 		return filepath.Join(home, ".claude")
 	}
 	return filepath.Join(projectPath, ".claude")
+}
+
+func (h claudeHarness) DefaultAssetDir(profileDir string) string {
+	for _, item := range h.ProfileDiscoveryItems() {
+		if _, err := os.Stat(filepath.Join(profileDir, item)); err == nil {
+			return "."
+		}
+	}
+	return h.Name()
+}
+
+func (h claudeHarness) ScaffoldAsset(kind, name string) (ScaffoldAsset, error) {
+	switch kind {
+	case "instructions":
+		return ScaffoldAsset{ProfilePath: h.MarkdownInstructionsFile(), Content: "# Profile Instructions\n\n", Mode: 0644}, nil
+	case "skill":
+		return ScaffoldAsset{ProfilePath: filepath.Join("skills", name, "SKILL.md"), Content: "---\ndescription: TODO\n---\n\n", Mode: 0644}, nil
+	case "agent":
+		return ScaffoldAsset{ProfilePath: filepath.Join("agents", name+".md"), Content: "# " + name + "\n\n", Mode: 0644}, nil
+	case "hook":
+		return ScaffoldAsset{ProfilePath: filepath.Join("hooks", name+".sh"), Content: "#!/usr/bin/env bash\nset -euo pipefail\n\n", Mode: 0755}, nil
+	default:
+		return ScaffoldAsset{}, fmt.Errorf("claude does not support %s scaffolding", kind)
+	}
 }
 
 func (claudeHarness) ManagedDirItems() []string {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -1,15 +1,27 @@
 package harness
 
-import "github.com/chichex/cvm/internal/config"
+import (
+	"os"
+
+	"github.com/chichex/cvm/internal/config"
+)
 
 type ManagedPath struct {
 	ProfilePath string
 	LivePath    string
 }
 
+type ScaffoldAsset struct {
+	ProfilePath string
+	Content     string
+	Mode        os.FileMode
+}
+
 type Harness interface {
 	Name() string
 	TargetDir(scope config.Scope, projectPath string) string
+	DefaultAssetDir(profileDir string) string
+	ScaffoldAsset(kind, name string) (ScaffoldAsset, error)
 	ManagedDirItems() []string
 	ExternalManagedPath(scope config.Scope, projectPath string) (ManagedPath, bool)
 	ProfileDiscoveryItems() []string

--- a/internal/harness/opencode.go
+++ b/internal/harness/opencode.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -36,6 +37,23 @@ func (opencodeHarness) TargetDir(scope config.Scope, projectPath string) string 
 	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".config", "opencode")
+}
+
+func (h opencodeHarness) DefaultAssetDir(profileDir string) string {
+	return h.Name()
+}
+
+func (h opencodeHarness) ScaffoldAsset(kind, name string) (ScaffoldAsset, error) {
+	switch kind {
+	case "instructions":
+		return ScaffoldAsset{ProfilePath: h.MarkdownInstructionsFile(), Content: "# Profile Instructions\n\n", Mode: 0644}, nil
+	case "skill":
+		return ScaffoldAsset{ProfilePath: filepath.Join("skills", name, "SKILL.md"), Content: "---\ndescription: TODO\n---\n\n", Mode: 0644}, nil
+	case "agent":
+		return ScaffoldAsset{ProfilePath: filepath.Join("agents", name+".md"), Content: "# " + name + "\n\n", Mode: 0644}, nil
+	default:
+		return ScaffoldAsset{}, fmt.Errorf("opencode does not support %s scaffolding", kind)
+	}
 }
 
 func (opencodeHarness) ManagedDirItems() []string {

--- a/internal/profile/authoring.go
+++ b/internal/profile/authoring.go
@@ -1,0 +1,253 @@
+package profile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chichex/cvm/internal/config"
+	"github.com/chichex/cvm/internal/harness"
+)
+
+type ScaffoldAssetOptions struct {
+	Scope       config.Scope
+	ProfileName string
+	ProjectPath string
+	Kind        string
+	Name        string
+	HarnessName string
+	FromFile    string
+}
+
+type ScaffoldedAsset struct {
+	Kind    string
+	Layer   string
+	Path    string
+	Created bool
+}
+
+func ScaffoldAsset(opts ScaffoldAssetOptions) (*ScaffoldedAsset, error) {
+	kind := strings.ToLower(strings.TrimSpace(opts.Kind))
+	if err := validateScaffoldRequest(kind, opts.Name); err != nil {
+		return nil, err
+	}
+	if opts.ProfileName == "" {
+		return nil, fmt.Errorf("profile name is required")
+	}
+
+	profileDir := ProfileDir(opts.Scope, opts.ProfileName)
+	info, err := os.Stat(profileDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("profile %q not found", opts.ProfileName)
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("profile %q is not a directory", opts.ProfileName)
+	}
+
+	harnessName := strings.TrimSpace(opts.HarnessName)
+	if kind == "hook" && harnessName == "" {
+		return nil, fmt.Errorf("hook assets are harness-specific; pass --harness <name>")
+	}
+
+	portable := harnessName == "" && kind != "hook"
+	if !portable {
+		h, ok := harness.ByName(harnessName)
+		if !ok {
+			return nil, fmt.Errorf("unknown harness %q", harnessName)
+		}
+		if err := validateHarnessScope(h, opts.Scope); err != nil {
+			return nil, err
+		}
+	}
+
+	hadManifest := HasManifest(profileDir)
+	manifest, err := LoadManifest(profileDir)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.Assets == nil {
+		manifest.Assets = map[string]string{}
+	}
+	if manifest.Name == "" {
+		manifest.Name = opts.ProfileName
+	}
+
+	assetDir, layer, changed, err := scaffoldAssetDir(profileDir, manifest, hadManifest, portable, harnessName)
+	if err != nil {
+		return nil, err
+	}
+
+	relPath, defaultContent, defaultMode := scaffoldFile(kind, opts.Name, harnessName, portable)
+	targetPath := filepath.Join(assetDir, relPath)
+	result := &ScaffoldedAsset{Kind: kind, Layer: layer, Path: targetPath}
+	if _, err := os.Stat(targetPath); err == nil {
+		if changed || !hadManifest {
+			if err := SaveManifest(profileDir, manifest); err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	content := []byte(defaultContent)
+	mode := defaultMode
+	if opts.FromFile != "" {
+		content, mode, err = readScaffoldSource(opts.FromFile, defaultMode, kind)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(targetPath, content, mode); err != nil {
+		return nil, err
+	}
+	if changed || !hadManifest {
+		if err := SaveManifest(profileDir, manifest); err != nil {
+			return nil, err
+		}
+	}
+	result.Created = true
+	return result, nil
+}
+
+func validateScaffoldRequest(kind, name string) error {
+	switch kind {
+	case "instructions":
+		if name != "" {
+			return fmt.Errorf("instructions does not take a name")
+		}
+		return nil
+	case "skill", "agent", "hook":
+		return validateAssetName(name)
+	default:
+		return fmt.Errorf("unknown type %q: must be one of skill, hook, agent, instructions", kind)
+	}
+}
+
+func validateAssetName(name string) error {
+	if name == "" {
+		return fmt.Errorf("asset name is required")
+	}
+	if name == "." || name == ".." || strings.Contains(name, "..") || strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("invalid name %q: must not contain path separators or '..'", name)
+	}
+	return nil
+}
+
+func scaffoldAssetDir(profileDir string, manifest *Manifest, hadManifest bool, portable bool, harnessName string) (string, string, bool, error) {
+	changed := false
+	if portable {
+		if _, ok := manifest.Assets["portable"]; !ok {
+			manifest.Assets["portable"] = "portable"
+			changed = true
+		}
+		if !hadManifest && manifest.SupportsHarness("claude") {
+			if _, ok := manifest.Assets["claude"]; !ok {
+				manifest.Assets["claude"] = defaultHarnessAssetDir(profileDir, "claude")
+				changed = true
+			}
+		}
+		assetDir, err := assetDirFromRaw(profileDir, manifest.Assets["portable"])
+		return assetDir, "portable", changed, err
+	}
+
+	if !manifest.SupportsHarness(harnessName) {
+		manifest.Harnesses = append(manifest.Harnesses, harnessName)
+		changed = true
+	}
+	if _, ok := manifest.Assets[harnessName]; !ok {
+		manifest.Assets[harnessName] = defaultHarnessAssetDir(profileDir, harnessName)
+		changed = true
+	}
+	assetDir, err := assetDirFromRaw(profileDir, manifest.Assets[harnessName])
+	return assetDir, harnessName, changed, err
+}
+
+func defaultHarnessAssetDir(profileDir string, harnessName string) string {
+	if harnessName == "claude" && legacyClaudeRootHasAssets(profileDir) {
+		return "."
+	}
+	return harnessName
+}
+
+func legacyClaudeRootHasAssets(profileDir string) bool {
+	for _, item := range harness.Claude().ProfileDiscoveryItems() {
+		if _, err := os.Stat(filepath.Join(profileDir, item)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func assetDirFromRaw(profileDir, raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "." {
+		return profileDir, nil
+	}
+	clean := filepath.Clean(raw)
+	if filepath.IsAbs(clean) {
+		return "", fmt.Errorf("asset dir %q must be relative", raw)
+	}
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("asset dir %q escapes the profile root", raw)
+	}
+	return filepath.Join(profileDir, clean), nil
+}
+
+func scaffoldFile(kind, name, harnessName string, portable bool) (string, string, os.FileMode) {
+	if portable {
+		switch kind {
+		case "instructions":
+			return "instructions.md", "# Profile Instructions\n\n", 0644
+		case "skill":
+			return filepath.Join("skills", name+".md"), "---\ndescription: TODO\n---\n\n", 0644
+		case "agent":
+			return filepath.Join("agents", name+".md"), "# " + name + "\n\n", 0644
+		}
+	}
+
+	switch kind {
+	case "instructions":
+		if h, ok := harness.ByName(harnessName); ok {
+			return h.MarkdownInstructionsFile(), "# Profile Instructions\n\n", 0644
+		}
+	case "skill":
+		return filepath.Join("skills", name, "SKILL.md"), "---\ndescription: TODO\n---\n\n", 0644
+	case "agent":
+		return filepath.Join("agents", name+".md"), "# " + name + "\n\n", 0644
+	case "hook":
+		return filepath.Join("hooks", name+".sh"), "#!/usr/bin/env bash\nset -euo pipefail\n\n", 0755
+	}
+	return name, "", 0644
+}
+
+func readScaffoldSource(path string, defaultMode os.FileMode, kind string) ([]byte, os.FileMode, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading --from-file %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return nil, 0, fmt.Errorf("--from-file %q is a directory", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading --from-file %q: %w", path, err)
+	}
+	mode := info.Mode().Perm()
+	if mode == 0 {
+		mode = defaultMode
+	}
+	if kind == "hook" {
+		mode = 0755
+	}
+	return data, mode, nil
+}

--- a/internal/profile/authoring.go
+++ b/internal/profile/authoring.go
@@ -21,10 +21,12 @@ type ScaffoldAssetOptions struct {
 }
 
 type ScaffoldedAsset struct {
-	Kind    string
-	Layer   string
-	Path    string
-	Created bool
+	Kind            string
+	Layer           string
+	Path            string
+	Created         bool
+	ManifestCreated bool
+	Portable        bool
 }
 
 func ScaffoldAsset(opts ScaffoldAssetOptions) (*ScaffoldedAsset, error) {
@@ -54,8 +56,11 @@ func ScaffoldAsset(opts ScaffoldAssetOptions) (*ScaffoldedAsset, error) {
 	}
 
 	portable := harnessName == "" && kind != "hook"
+	var selectedHarness harness.Harness
 	if !portable {
-		if _, ok := harness.ByName(harnessName); !ok {
+		var ok bool
+		selectedHarness, ok = harness.ByName(harnessName)
+		if !ok {
 			return nil, fmt.Errorf("unknown harness %q", harnessName)
 		}
 	}
@@ -72,19 +77,23 @@ func ScaffoldAsset(opts ScaffoldAssetOptions) (*ScaffoldedAsset, error) {
 		manifest.Name = opts.ProfileName
 	}
 
-	assetDir, layer, changed, err := scaffoldAssetDir(profileDir, manifest, hadManifest, portable, harnessName)
+	assetDir, layer, changed, err := scaffoldAssetDir(profileDir, manifest, hadManifest, portable, selectedHarness)
 	if err != nil {
 		return nil, err
 	}
 
-	relPath, defaultContent, defaultMode := scaffoldFile(kind, opts.Name, harnessName, portable)
+	relPath, defaultContent, defaultMode, err := scaffoldFile(kind, opts.Name, portable, selectedHarness)
+	if err != nil {
+		return nil, err
+	}
 	targetPath := filepath.Join(assetDir, relPath)
-	result := &ScaffoldedAsset{Kind: kind, Layer: layer, Path: targetPath}
+	result := &ScaffoldedAsset{Kind: kind, Layer: layer, Path: targetPath, Portable: portable}
 	if _, err := os.Stat(targetPath); err == nil {
 		if changed || !hadManifest {
 			if err := SaveManifest(profileDir, manifest); err != nil {
 				return nil, err
 			}
+			result.ManifestCreated = !hadManifest
 		}
 		return result, nil
 	} else if err != nil && !os.IsNotExist(err) {
@@ -110,6 +119,7 @@ func ScaffoldAsset(opts ScaffoldAssetOptions) (*ScaffoldedAsset, error) {
 		if err := SaveManifest(profileDir, manifest); err != nil {
 			return nil, err
 		}
+		result.ManifestCreated = !hadManifest
 	}
 	result.Created = true
 	return result, nil
@@ -139,7 +149,7 @@ func validateAssetName(name string) error {
 	return nil
 }
 
-func scaffoldAssetDir(profileDir string, manifest *Manifest, hadManifest bool, portable bool, harnessName string) (string, string, bool, error) {
+func scaffoldAssetDir(profileDir string, manifest *Manifest, hadManifest bool, portable bool, h harness.Harness) (string, string, bool, error) {
 	changed := false
 	if portable {
 		if _, ok := manifest.Assets["portable"]; !ok {
@@ -148,7 +158,8 @@ func scaffoldAssetDir(profileDir string, manifest *Manifest, hadManifest bool, p
 		}
 		if !hadManifest && manifest.SupportsHarness("claude") {
 			if _, ok := manifest.Assets["claude"]; !ok {
-				manifest.Assets["claude"] = defaultHarnessAssetDir(profileDir, "claude")
+				claude, _ := harness.ByName("claude")
+				manifest.Assets["claude"] = claude.DefaultAssetDir(profileDir)
 				changed = true
 			}
 		}
@@ -156,32 +167,16 @@ func scaffoldAssetDir(profileDir string, manifest *Manifest, hadManifest bool, p
 		return assetDir, "portable", changed, err
 	}
 
-	if !manifest.SupportsHarness(harnessName) {
-		manifest.Harnesses = append(manifest.Harnesses, harnessName)
+	if !manifest.SupportsHarness(h.Name()) {
+		manifest.Harnesses = append(manifest.Harnesses, h.Name())
 		changed = true
 	}
-	if _, ok := manifest.Assets[harnessName]; !ok {
-		manifest.Assets[harnessName] = defaultHarnessAssetDir(profileDir, harnessName)
+	if _, ok := manifest.Assets[h.Name()]; !ok {
+		manifest.Assets[h.Name()] = h.DefaultAssetDir(profileDir)
 		changed = true
 	}
-	assetDir, err := assetDirFromRaw(profileDir, manifest.Assets[harnessName])
-	return assetDir, harnessName, changed, err
-}
-
-func defaultHarnessAssetDir(profileDir string, harnessName string) string {
-	if harnessName == "claude" && legacyClaudeRootHasAssets(profileDir) {
-		return "."
-	}
-	return harnessName
-}
-
-func legacyClaudeRootHasAssets(profileDir string) bool {
-	for _, item := range harness.Claude().ProfileDiscoveryItems() {
-		if _, err := os.Stat(filepath.Join(profileDir, item)); err == nil {
-			return true
-		}
-	}
-	return false
+	assetDir, err := assetDirFromRaw(profileDir, manifest.Assets[h.Name()])
+	return assetDir, h.Name(), changed, err
 }
 
 func assetDirFromRaw(profileDir, raw string) (string, error) {
@@ -199,31 +194,23 @@ func assetDirFromRaw(profileDir, raw string) (string, error) {
 	return filepath.Join(profileDir, clean), nil
 }
 
-func scaffoldFile(kind, name, harnessName string, portable bool) (string, string, os.FileMode) {
+func scaffoldFile(kind, name string, portable bool, h harness.Harness) (string, string, os.FileMode, error) {
 	if portable {
 		switch kind {
 		case "instructions":
-			return "instructions.md", "# Profile Instructions\n\n", 0644
+			return "instructions.md", "# Profile Instructions\n\n", 0644, nil
 		case "skill":
-			return filepath.Join("skills", name+".md"), "---\ndescription: TODO\n---\n\n", 0644
+			return filepath.Join("skills", name+".md"), "---\ndescription: TODO\n---\n\n", 0644, nil
 		case "agent":
-			return filepath.Join("agents", name+".md"), "# " + name + "\n\n", 0644
+			return filepath.Join("agents", name+".md"), "# " + name + "\n\n", 0644, nil
 		}
 	}
 
-	switch kind {
-	case "instructions":
-		if h, ok := harness.ByName(harnessName); ok {
-			return h.MarkdownInstructionsFile(), "# Profile Instructions\n\n", 0644
-		}
-	case "skill":
-		return filepath.Join("skills", name, "SKILL.md"), "---\ndescription: TODO\n---\n\n", 0644
-	case "agent":
-		return filepath.Join("agents", name+".md"), "# " + name + "\n\n", 0644
-	case "hook":
-		return filepath.Join("hooks", name+".sh"), "#!/usr/bin/env bash\nset -euo pipefail\n\n", 0755
+	asset, err := h.ScaffoldAsset(kind, name)
+	if err != nil {
+		return "", "", 0, err
 	}
-	return name, "", 0644
+	return asset.ProfilePath, asset.Content, asset.Mode, nil
 }
 
 func readScaffoldSource(path string, defaultMode os.FileMode, kind string) ([]byte, os.FileMode, error) {

--- a/internal/profile/authoring.go
+++ b/internal/profile/authoring.go
@@ -55,12 +55,8 @@ func ScaffoldAsset(opts ScaffoldAssetOptions) (*ScaffoldedAsset, error) {
 
 	portable := harnessName == "" && kind != "hook"
 	if !portable {
-		h, ok := harness.ByName(harnessName)
-		if !ok {
+		if _, ok := harness.ByName(harnessName); !ok {
 			return nil, fmt.Errorf("unknown harness %q", harnessName)
-		}
-		if err := validateHarnessScope(h, opts.Scope); err != nil {
-			return nil, err
 		}
 	}
 

--- a/internal/profile/authoring.go
+++ b/internal/profile/authoring.go
@@ -156,12 +156,8 @@ func scaffoldAssetDir(profileDir string, manifest *Manifest, hadManifest bool, p
 			manifest.Assets["portable"] = "portable"
 			changed = true
 		}
-		if !hadManifest && manifest.SupportsHarness("claude") {
-			if _, ok := manifest.Assets["claude"]; !ok {
-				claude, _ := harness.ByName("claude")
-				manifest.Assets["claude"] = claude.DefaultAssetDir(profileDir)
-				changed = true
-			}
+		if !hadManifest {
+			changed = preserveLegacyRootAssetDirs(profileDir, manifest) || changed
 		}
 		assetDir, err := assetDirFromRaw(profileDir, manifest.Assets["portable"])
 		return assetDir, "portable", changed, err
@@ -177,6 +173,24 @@ func scaffoldAssetDir(profileDir string, manifest *Manifest, hadManifest bool, p
 	}
 	assetDir, err := assetDirFromRaw(profileDir, manifest.Assets[h.Name()])
 	return assetDir, h.Name(), changed, err
+}
+
+func preserveLegacyRootAssetDirs(profileDir string, manifest *Manifest) bool {
+	changed := false
+	for _, harnessName := range manifest.Harnesses {
+		if _, ok := manifest.Assets[harnessName]; ok {
+			continue
+		}
+		h, ok := harness.ByName(harnessName)
+		if !ok {
+			continue
+		}
+		if h.DefaultAssetDir(profileDir) == "." {
+			manifest.Assets[harnessName] = "."
+			changed = true
+		}
+	}
+	return changed
 }
 
 func assetDirFromRaw(profileDir, raw string) (string, error) {

--- a/internal/profile/manifest.go
+++ b/internal/profile/manifest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -125,6 +126,75 @@ func (m *Manifest) AssetDir(profileDir string, h harness.Harness) (string, error
 func HasManifest(profileDir string) bool {
 	_, err := os.Stat(filepath.Join(profileDir, manifestFileName))
 	return err == nil
+}
+
+func SaveManifest(profileDir string, manifest *Manifest) error {
+	if manifest.Name == "" {
+		manifest.Name = filepath.Base(profileDir)
+	}
+	if len(manifest.Harnesses) == 0 {
+		return fmt.Errorf("harnesses must not be empty")
+	}
+
+	var b strings.Builder
+	b.WriteString("name = ")
+	b.WriteString(strconv.Quote(manifest.Name))
+	b.WriteByte('\n')
+	b.WriteString("harnesses = [")
+	for i, harnessName := range manifest.Harnesses {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(strconv.Quote(harnessName))
+	}
+	b.WriteString("]\n")
+
+	keys := manifestAssetKeys(manifest)
+	if len(keys) > 0 {
+		b.WriteString("\n[assets]\n")
+		for _, key := range keys {
+			b.WriteString(key)
+			b.WriteString(" = ")
+			b.WriteString(strconv.Quote(manifest.Assets[key]))
+			b.WriteByte('\n')
+		}
+	}
+
+	if err := os.MkdirAll(profileDir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(profileDir, manifestFileName), []byte(b.String()), 0644)
+}
+
+func manifestAssetKeys(manifest *Manifest) []string {
+	if len(manifest.Assets) == 0 {
+		return nil
+	}
+
+	seen := map[string]bool{}
+	keys := []string{}
+	appendKey := func(key string) {
+		if _, ok := manifest.Assets[key]; !ok || seen[key] {
+			return
+		}
+		seen[key] = true
+		keys = append(keys, key)
+	}
+
+	appendKey("portable")
+	for _, harnessName := range manifest.Harnesses {
+		appendKey(harnessName)
+	}
+
+	remaining := make([]string, 0, len(manifest.Assets)-len(keys))
+	for key := range manifest.Assets {
+		if !seen[key] {
+			remaining = append(remaining, key)
+		}
+	}
+	sort.Strings(remaining)
+	keys = append(keys, remaining...)
+	return keys
 }
 
 func LooksLikeProfileDir(profileDir string) bool {

--- a/internal/profile/vanilla_test.go
+++ b/internal/profile/vanilla_test.go
@@ -25,6 +25,14 @@ func (h testHarness) TargetDir(scope config.Scope, projectPath string) string {
 	return h.targetDir
 }
 
+func (h testHarness) DefaultAssetDir(profileDir string) string {
+	return h.name
+}
+
+func (h testHarness) ScaffoldAsset(kind, name string) (harness.ScaffoldAsset, error) {
+	return harness.ScaffoldAsset{ProfilePath: "CONFIG.md", Content: "", Mode: 0644}, nil
+}
+
 func (h testHarness) ManagedDirItems() []string {
 	return []string{"CONFIG.md"}
 }


### PR DESCRIPTION
## Summary
- Add `cvm profile add` scaffolding for portable `instructions`, `skill`, and `agent` assets.
- Add harness-specific authoring via `--harness`, with hooks requiring a harness and support for `--from-file` / `--open`.
- Persist manifest asset mappings and document the authoring workflow.

## Testing
- `go test ./...`

Closes #39