### PR TITLE
Add portable plan skill

### DIFF
--- a/profiles/portable/opencode/skills/portable-plan/SKILL.md
+++ b/profiles/portable/opencode/skills/portable-plan/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: portable-plan
 description: Crear un plan de implementacion desde un issue de spec y abrir un PR con label entity:plan
 ---
 

--- a/profiles/portable/opencode/skills/portable-spec/SKILL.md
+++ b/profiles/portable/opencode/skills/portable-spec/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: portable-spec
 description: Definir una spec interactiva desde una historia de usuario y crear un issue GitHub con label entity:spec
 ---
 


### PR DESCRIPTION
## Summary
- Add `/portable-plan` to the portable Claude and OpenCode profiles.
- Preserve OpenCode user config while managing the profile-owned `skills.paths` entry.
- Add required OpenCode skill metadata so `portable-spec` and `portable-plan` are discoverable.

## Tests
- `go test ./...`