### PR TITLE
Extend bypass command to OpenCode and Codex

### DIFF
--- a/.portable/plans/59-extend-bypass-command-to-opencode-and-codex.md
+++ b/.portable/plans/59-extend-bypass-command-to-opencode-and-codex.md
@@ -1,0 +1,51 @@
+# Plan: Extend bypass command to OpenCode and Codex (adoptado post-hoc)
+
+Refs #59 · https://github.com/chichex/cvm/pull/59
+
+> **Nota**: este plan fue generado automaticamente por `/portable-recover` a partir del PR existente. No paso por el flujo interactivo de `/portable-plan`. El usuario puede enriquecerlo antes de validar.
+
+## Contexto
+
+El PR extiende `cvm bypass` para operar por harness, manteniendo el formato de Claude, agregando soporte para OpenCode mediante `permission: allow` en `opencode.json`, y soporte para Codex mediante `approval_policy = "never"` y `sandbox_mode = "danger-full-access"` en `~/.codex/config.toml`. El body reporta que `go build ./...`, `go vet ./...` y `go test ./...` pasaron, con nuevas pruebas en `internal/harness/bypass_test.go`.
+
+## Objetivo
+
+Extend bypass command to OpenCode and Codex
+
+## Approach
+
+_(adoptado post-hoc; ver archivos afectados)_
+
+## Pasos
+
+- [x] cmd/bypass.go
+- [x] internal/harness/bypass_test.go
+- [x] internal/harness/claude.go
+- [x] internal/harness/codex.go
+- [x] internal/harness/harness.go
+- [x] internal/harness/opencode.go
+- [x] internal/profile/vanilla_test.go
+- [x] profiles/portable/opencode/AGENTS.md
+
+## Archivos afectados
+
+- `cmd/bypass.go`
+- `internal/harness/bypass_test.go`
+- `internal/harness/claude.go`
+- `internal/harness/codex.go`
+- `internal/harness/harness.go`
+- `internal/harness/opencode.go`
+- `internal/profile/vanilla_test.go`
+- `profiles/portable/opencode/AGENTS.md`
+
+## Riesgos
+
+_(no relevados; plan adoptado post-hoc)_
+
+## Out of scope
+
+_(no relevado; plan adoptado post-hoc)_
+
+## Asunciones tecnicas validadas
+
+1. Este plan fue generado automaticamente por `/portable-recover`. Los detalles de implementacion se infieren del diff del PR y no fueron validados interactivamente.

--- a/cmd/bypass.go
+++ b/cmd/bypass.go
@@ -2,19 +2,24 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
+	"sort"
 
+	"github.com/chichex/cvm/internal/harness"
 	"github.com/chichex/cvm/internal/profile"
-	"github.com/chichex/cvm/internal/settings"
+	"github.com/chichex/cvm/internal/state"
 	"github.com/spf13/cobra"
 )
 
 var bypassCmd = &cobra.Command{
 	Use:   "bypass [on|off|status]",
 	Short: "Inspect or change bypass permissions for active profiles",
-	Long:  `Bypass permissions are persisted as overrides, so they survive 'cvm pull'.`,
-	Args:  cobra.MaximumNArgs(1),
+	Long: `Bypass permissions are persisted as overrides where possible, so they
+survive 'cvm pull'. Codex stores bypass directly in ~/.codex/config.toml
+because cvm has no TOML-level override merge yet.
+
+By default the command targets every harness with an active profile. Use
+--harness to scope to one of: claude, opencode, codex.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mode := "status"
 		if len(args) > 0 {
@@ -35,11 +40,12 @@ var bypassCmd = &cobra.Command{
 }
 
 func init() {
+	bypassCmd.Flags().String("harness", "", "Harness to target (claude, opencode, codex). Default: every active harness")
 }
 
 type bypassTarget struct {
+	harness     harness.Harness
 	profileName string
-	overrideDir string
 }
 
 func showBypassStatus(cmd *cobra.Command) error {
@@ -53,15 +59,14 @@ func showBypassStatus(cmd *cobra.Command) error {
 	}
 
 	for _, target := range targets {
-		overrideSettings := filepath.Join(target.overrideDir, "settings.json")
-		mode, err := settings.GetPermissionsMode(overrideSettings)
+		mode, err := target.harness.BypassStatus(target.profileName)
 		if err != nil {
 			mode = ""
 		}
 		if mode == "" {
 			mode = "(default)"
 		}
-		fmt.Printf("profile %q: %s\n", target.profileName, mode)
+		fmt.Printf("%s profile %q: %s\n", target.harness.Name(), target.profileName, mode)
 	}
 	return nil
 }
@@ -76,29 +81,17 @@ func enableBypass(cmd *cobra.Command) error {
 	}
 
 	for _, target := range targets {
-		overrideSettings := filepath.Join(target.overrideDir, "settings.json")
-
-		cfg, err := settings.Read(overrideSettings)
-		if err != nil {
-			return err
+		if err := target.harness.EnableBypass(target.profileName); err != nil {
+			return fmt.Errorf("%s: %w", target.harness.Name(), err)
 		}
-
-		bypassCfg := settings.BypassConfig()
-		for k, v := range bypassCfg {
-			cfg[k] = v
+		if err := profile.ReapplyWithHarness(target.profileName, target.harness); err != nil {
+			return fmt.Errorf("%s: %w", target.harness.Name(), err)
 		}
-
-		if err := os.MkdirAll(target.overrideDir, 0755); err != nil {
-			return err
+		mode, err := target.harness.BypassStatus(target.profileName)
+		if err != nil || mode == "" {
+			mode = "bypassPermissions"
 		}
-		if err := settings.Write(overrideSettings, cfg); err != nil {
-			return err
-		}
-
-		if err := profile.Reapply(target.profileName); err != nil {
-			return err
-		}
-		fmt.Printf("profile %q: bypassPermissions\n", target.profileName)
+		fmt.Printf("%s profile %q: %s\n", target.harness.Name(), target.profileName, mode)
 	}
 
 	return nil
@@ -114,38 +107,58 @@ func disableBypass(cmd *cobra.Command) error {
 	}
 
 	for _, target := range targets {
-		overrideSettings := filepath.Join(target.overrideDir, "settings.json")
-
-		cfg, err := settings.Read(overrideSettings)
-		if err != nil {
-			return err
+		if err := target.harness.DisableBypass(target.profileName); err != nil {
+			return fmt.Errorf("%s: %w", target.harness.Name(), err)
 		}
-
-		if settings.RemovePermissions(cfg) {
-			os.Remove(overrideSettings)
-		} else {
-			if err := settings.Write(overrideSettings, cfg); err != nil {
-				return err
-			}
+		if err := profile.ReapplyWithHarness(target.profileName, target.harness); err != nil {
+			return fmt.Errorf("%s: %w", target.harness.Name(), err)
 		}
-
-		if err := profile.Reapply(target.profileName); err != nil {
-			return err
-		}
-		fmt.Printf("profile %q: default\n", target.profileName)
+		fmt.Printf("%s profile %q: default\n", target.harness.Name(), target.profileName)
 	}
 
 	return nil
 }
 
+// activeBypassTargets resolves the list of (harness, active profile) pairs to
+// operate on. With --harness, only that harness is considered; otherwise we
+// iterate every harness that currently has an active profile.
 func activeBypassTargets(cmd *cobra.Command) ([]bypassTarget, error) {
-	name, err := profile.Current()
+	st, err := state.Load()
 	if err != nil {
 		return nil, err
 	}
-	if name == "" {
-		return nil, nil
+
+	flagSet := cmd.Flags().Changed("harness")
+	if flagSet {
+		h, err := harnessFromFlag(cmd)
+		if err != nil {
+			return nil, err
+		}
+		name := st.GetGlobalHarness(h.Name())
+		if name == "" {
+			return nil, nil
+		}
+		return []bypassTarget{{harness: h, profileName: name}}, nil
 	}
 
-	return []bypassTarget{{profileName: name, overrideDir: profile.OverrideDir(name)}}, nil
+	// No flag: every active harness.
+	names := make([]string, 0, len(st.Global.Harnesses))
+	for n := range st.Global.Harnesses {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	targets := make([]bypassTarget, 0, len(names))
+	for _, hName := range names {
+		h, ok := harness.ByName(hName)
+		if !ok {
+			continue
+		}
+		profileName := st.GetGlobalHarness(hName)
+		if profileName == "" {
+			continue
+		}
+		targets = append(targets, bypassTarget{harness: h, profileName: profileName})
+	}
+	return targets, nil
 }

--- a/internal/harness/bypass_test.go
+++ b/internal/harness/bypass_test.go
@@ -1,0 +1,398 @@
+package harness
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chichex/cvm/internal/config"
+)
+
+// withTempHome points HOME (and harness-specific config-dir env vars) at a
+// temp dir so each subtest has its own clean ~/.cvm and ~/.codex/~/.config.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("OPENCODE_CONFIG_DIR", "")
+	return home
+}
+
+// ---------------------------------------------------------------------------
+// Claude
+// ---------------------------------------------------------------------------
+
+func TestClaudeBypassEnableWritesOverrideSettings(t *testing.T) {
+	withTempHome(t)
+	const profileName = "work"
+
+	if err := Claude().EnableBypass(profileName); err != nil {
+		t.Fatalf("enable bypass: %v", err)
+	}
+
+	overridePath := filepath.Join(config.OverrideDir(profileName), "settings.json")
+	data, err := os.ReadFile(overridePath)
+	if err != nil {
+		t.Fatalf("read override settings: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal override settings: %v", err)
+	}
+	perms, ok := cfg["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected permissions map, got %T", cfg["permissions"])
+	}
+	if got, want := perms["defaultMode"], "bypassPermissions"; got != want {
+		t.Fatalf("defaultMode = %v, want %v", got, want)
+	}
+	if _, ok := perms["allow"].([]any); !ok {
+		t.Fatalf("expected allow list, got %T", perms["allow"])
+	}
+
+	mode, err := Claude().BypassStatus(profileName)
+	if err != nil {
+		t.Fatalf("bypass status: %v", err)
+	}
+	if mode != "bypassPermissions" {
+		t.Fatalf("status = %q, want bypassPermissions", mode)
+	}
+}
+
+func TestClaudeBypassDisablePreservesUnrelatedKeys(t *testing.T) {
+	withTempHome(t)
+	const profileName = "work"
+
+	overridePath := filepath.Join(config.OverrideDir(profileName), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(overridePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	preexisting := map[string]any{
+		"theme": "dark",
+		"permissions": map[string]any{
+			"defaultMode": "ask",
+		},
+	}
+	data, _ := json.MarshalIndent(preexisting, "", "  ")
+	if err := os.WriteFile(overridePath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Claude().EnableBypass(profileName); err != nil {
+		t.Fatalf("enable bypass: %v", err)
+	}
+	if err := Claude().DisableBypass(profileName); err != nil {
+		t.Fatalf("disable bypass: %v", err)
+	}
+
+	// theme=dark should survive; permissions key should be gone — file may
+	// remain because non-permissions keys are preserved.
+	got, err := os.ReadFile(overridePath)
+	if err != nil {
+		t.Fatalf("read after disable: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(got, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg["theme"] != "dark" {
+		t.Fatalf("expected theme to be preserved, got %v", cfg["theme"])
+	}
+	if _, ok := cfg["permissions"]; ok {
+		t.Fatalf("permissions should have been removed: %v", cfg)
+	}
+}
+
+func TestClaudeBypassDisableEmptyOverrideRemovesFile(t *testing.T) {
+	withTempHome(t)
+	const profileName = "work"
+
+	if err := Claude().EnableBypass(profileName); err != nil {
+		t.Fatal(err)
+	}
+	if err := Claude().DisableBypass(profileName); err != nil {
+		t.Fatal(err)
+	}
+
+	overridePath := filepath.Join(config.OverrideDir(profileName), "settings.json")
+	if _, err := os.Stat(overridePath); !os.IsNotExist(err) {
+		t.Fatalf("expected override settings.json to be removed, stat err=%v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OpenCode
+// ---------------------------------------------------------------------------
+
+func TestOpenCodeBypassEnableShorthand(t *testing.T) {
+	withTempHome(t)
+	const profileName = "work"
+
+	if err := OpenCode().EnableBypass(profileName); err != nil {
+		t.Fatalf("enable bypass: %v", err)
+	}
+
+	overridePath := filepath.Join(config.OverrideDir(profileName), "opencode.json")
+	data, err := os.ReadFile(overridePath)
+	if err != nil {
+		t.Fatalf("read override opencode.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, want := cfg["permission"], "allow"; got != want {
+		t.Fatalf("permission = %v, want %v", got, want)
+	}
+
+	status, err := OpenCode().BypassStatus(profileName)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status != "allow" {
+		t.Fatalf("status = %q, want allow", status)
+	}
+}
+
+func TestOpenCodeBypassPreservesOtherKeys(t *testing.T) {
+	withTempHome(t)
+	const profileName = "work"
+
+	overridePath := filepath.Join(config.OverrideDir(profileName), "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(overridePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	preexisting := map[string]any{
+		"mcpServers": map[string]any{
+			"foo": map[string]any{"command": "bar"},
+		},
+		"theme": "tokyo-night",
+	}
+	data, _ := json.MarshalIndent(preexisting, "", "  ")
+	if err := os.WriteFile(overridePath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := OpenCode().EnableBypass(profileName); err != nil {
+		t.Fatalf("enable bypass: %v", err)
+	}
+
+	got, _ := os.ReadFile(overridePath)
+	var cfg map[string]any
+	if err := json.Unmarshal(got, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg["theme"] != "tokyo-night" {
+		t.Fatalf("theme dropped: %v", cfg)
+	}
+	if _, ok := cfg["mcpServers"].(map[string]any); !ok {
+		t.Fatalf("mcpServers dropped: %v", cfg)
+	}
+	if cfg["permission"] != "allow" {
+		t.Fatalf("permission not set: %v", cfg)
+	}
+
+	if err := OpenCode().DisableBypass(profileName); err != nil {
+		t.Fatalf("disable bypass: %v", err)
+	}
+
+	got2, _ := os.ReadFile(overridePath)
+	var cfg2 map[string]any
+	if err := json.Unmarshal(got2, &cfg2); err != nil {
+		t.Fatalf("unmarshal after disable: %v", err)
+	}
+	if _, ok := cfg2["permission"]; ok {
+		t.Fatalf("permission should be removed: %v", cfg2)
+	}
+	if cfg2["theme"] != "tokyo-night" {
+		t.Fatalf("theme dropped after disable: %v", cfg2)
+	}
+}
+
+func TestOpenCodeBypassDisableNonexistentIsNoOp(t *testing.T) {
+	withTempHome(t)
+	if err := OpenCode().DisableBypass("ghost"); err != nil {
+		t.Fatalf("disable on missing file should be no-op, got %v", err)
+	}
+	mode, err := OpenCode().BypassStatus("ghost")
+	if err != nil {
+		t.Fatalf("status on missing file should be no-op, got %v", err)
+	}
+	if mode != "" {
+		t.Fatalf("status = %q, want empty", mode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Codex
+// ---------------------------------------------------------------------------
+
+func TestCodexBypassEnableWritesConfigToml(t *testing.T) {
+	home := withTempHome(t)
+	if err := Codex().EnableBypass("any"); err != nil {
+		t.Fatalf("enable bypass: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, `approval_policy = "never"`) {
+		t.Fatalf("missing approval_policy line:\n%s", out)
+	}
+	if !strings.Contains(out, `sandbox_mode = "danger-full-access"`) {
+		t.Fatalf("missing sandbox_mode line:\n%s", out)
+	}
+
+	mode, err := Codex().BypassStatus("any")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if mode != "danger-full-access/never" {
+		t.Fatalf("status = %q, want danger-full-access/never", mode)
+	}
+}
+
+func TestCodexBypassPreservesExistingTomlContent(t *testing.T) {
+	home := withTempHome(t)
+	cfgDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	original := `# user comment at top
+model = "o4-mini"
+approval_policy = "on-request"
+
+[mcp_servers.foo]
+command = "bar"
+`
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Codex().EnableBypass("any"); err != nil {
+		t.Fatalf("enable bypass: %v", err)
+	}
+
+	got, _ := os.ReadFile(cfgPath)
+	out := string(got)
+
+	// Existing top-level approval_policy should be replaced in place.
+	if strings.Count(out, "approval_policy =") != 1 {
+		t.Fatalf("expected exactly one approval_policy line:\n%s", out)
+	}
+	if !strings.Contains(out, `approval_policy = "never"`) {
+		t.Fatalf("approval_policy not flipped:\n%s", out)
+	}
+	// sandbox_mode is new; must be appended before the [mcp_servers.foo] section.
+	if !strings.Contains(out, `sandbox_mode = "danger-full-access"`) {
+		t.Fatalf("sandbox_mode missing:\n%s", out)
+	}
+	idxSandbox := strings.Index(out, "sandbox_mode")
+	idxSection := strings.Index(out, "[mcp_servers.foo]")
+	if idxSandbox < 0 || idxSection < 0 || idxSandbox > idxSection {
+		t.Fatalf("sandbox_mode should be in top-level region (before section):\n%s", out)
+	}
+	// Pre-existing comment, model line, and section body must survive.
+	if !strings.Contains(out, "# user comment at top") {
+		t.Fatalf("dropped top-of-file comment:\n%s", out)
+	}
+	if !strings.Contains(out, `model = "o4-mini"`) {
+		t.Fatalf("dropped existing model line:\n%s", out)
+	}
+	if !strings.Contains(out, "[mcp_servers.foo]") || !strings.Contains(out, `command = "bar"`) {
+		t.Fatalf("dropped mcp_servers section:\n%s", out)
+	}
+}
+
+func TestCodexBypassDisableStripsKeys(t *testing.T) {
+	home := withTempHome(t)
+	if err := Codex().EnableBypass("any"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Codex().DisableBypass("any"); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	cfgPath := filepath.Join(home, ".codex", "config.toml")
+	// File should be removed when only-bypass content is stripped.
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Fatalf("expected config.toml removed when only bypass keys were present, stat=%v", err)
+	}
+
+	mode, err := Codex().BypassStatus("any")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if mode != "" {
+		t.Fatalf("status = %q, want empty", mode)
+	}
+}
+
+func TestCodexBypassDisableKeepsFileWithOtherContent(t *testing.T) {
+	home := withTempHome(t)
+	cfgDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("model = \"o4-mini\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Codex().EnableBypass("any"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Codex().DisableBypass("any"); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	got, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("config.toml should still exist with non-bypass keys: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, `model = "o4-mini"`) {
+		t.Fatalf("dropped model key:\n%s", out)
+	}
+	if strings.Contains(out, "approval_policy") || strings.Contains(out, "sandbox_mode") {
+		t.Fatalf("bypass keys should be stripped:\n%s", out)
+	}
+}
+
+func TestCodexBypassStatusMissingFileEmpty(t *testing.T) {
+	withTempHome(t)
+	mode, err := Codex().BypassStatus("any")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if mode != "" {
+		t.Fatalf("status = %q, want empty", mode)
+	}
+}
+
+func TestCodexBypassStatusOnlyOneKeyIsNotBypassed(t *testing.T) {
+	home := withTempHome(t)
+	cfgDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// approval_policy=never alone (no sandbox_mode) must not count as bypass.
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"),
+		[]byte(`approval_policy = "never"`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mode, err := Codex().BypassStatus("any")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if mode != "" {
+		t.Fatalf("status = %q, want empty (only one key)", mode)
+	}
+}

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/chichex/cvm/internal/config"
+	"github.com/chichex/cvm/internal/settings"
 )
 
 type claudeHarness struct{}
@@ -96,4 +99,53 @@ func (claudeHarness) IsUserMCPPath(profilePath string) bool {
 
 func (claudeHarness) IsMCPPath(profilePath string) bool {
 	return profilePath == ".claude.json"
+}
+
+// EnableBypass writes Claude's bypass permissions block to the profile's
+// override settings.json. Reapply (called by the bypass command after) will
+// then merge it into the live ~/.claude/settings.json.
+func (claudeHarness) EnableBypass(profileName string) error {
+	overrideDir := config.OverrideDir(profileName)
+	overrideSettings := filepath.Join(overrideDir, "settings.json")
+
+	cfg, err := settings.Read(overrideSettings)
+	if err != nil {
+		return err
+	}
+	for k, v := range settings.BypassConfig() {
+		cfg[k] = v
+	}
+	if err := os.MkdirAll(overrideDir, 0755); err != nil {
+		return err
+	}
+	return settings.Write(overrideSettings, cfg)
+}
+
+// DisableBypass strips the bypass permissions block from the profile's
+// override settings.json. The override file is removed entirely if no other
+// keys remain.
+func (claudeHarness) DisableBypass(profileName string) error {
+	overrideSettings := filepath.Join(config.OverrideDir(profileName), "settings.json")
+	cfg, err := settings.Read(overrideSettings)
+	if err != nil {
+		return err
+	}
+	if settings.RemovePermissions(cfg) {
+		if err := os.Remove(overrideSettings); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	return settings.Write(overrideSettings, cfg)
+}
+
+// BypassStatus reads the override settings.json and returns the current
+// permissions.defaultMode value. Empty string means "not bypassed".
+func (claudeHarness) BypassStatus(profileName string) (string, error) {
+	overrideSettings := filepath.Join(config.OverrideDir(profileName), "settings.json")
+	mode, err := settings.GetPermissionsMode(overrideSettings)
+	if err != nil {
+		return "", err
+	}
+	return mode, nil
 }

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -1,9 +1,25 @@
 package harness
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+)
+
+// Codex bypass keys, sourced from
+// https://developers.openai.com/codex/config-reference. Together they put
+// Codex into "no approvals + unrestricted sandbox" mode — the closest
+// equivalent to Claude's bypassPermissions / OpenCode's permission=allow.
+const (
+	codexConfigFile        = "config.toml"
+	codexApprovalKey       = "approval_policy"
+	codexApprovalBypass    = "never"
+	codexSandboxKey        = "sandbox_mode"
+	codexSandboxBypass     = "danger-full-access"
+	codexBypassStatusValue = "danger-full-access/never"
 )
 
 type codexHarness struct{}
@@ -74,4 +90,318 @@ func (codexHarness) IsUserMCPPath(profilePath string) bool {
 func (codexHarness) IsMCPPath(profilePath string) bool {
 	// Revisit this if Codex gains a managed MCP asset so additive merge rules apply.
 	return false
+}
+
+// EnableBypass writes Codex's bypass keys directly to the live config.toml.
+// config.toml is not part of the managed item set (cvm has no TOML merge
+// semantics yet), so the override mechanism is bypassed and we mutate the
+// live file in place — preserving any unrelated keys/sections the user has.
+//
+// profileName is accepted for interface symmetry but unused: Codex bypass
+// state lives on the live config, not in per-profile overrides.
+func (h codexHarness) EnableBypass(_ string) error {
+	path := filepath.Join(h.TargetDir(), codexConfigFile)
+	return setCodexTopLevelKeys(path, map[string]string{
+		codexApprovalKey: quoteTOMLString(codexApprovalBypass),
+		codexSandboxKey:  quoteTOMLString(codexSandboxBypass),
+	})
+}
+
+// DisableBypass strips the two bypass keys from the live config.toml.
+func (h codexHarness) DisableBypass(_ string) error {
+	path := filepath.Join(h.TargetDir(), codexConfigFile)
+	return removeCodexTopLevelKeys(path, []string{codexApprovalKey, codexSandboxKey})
+}
+
+// BypassStatus returns a non-empty status string if both bypass keys are
+// present with their bypass values; otherwise "".
+func (h codexHarness) BypassStatus(_ string) (string, error) {
+	path := filepath.Join(h.TargetDir(), codexConfigFile)
+	values, err := readCodexTopLevelKeys(path, []string{codexApprovalKey, codexSandboxKey})
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if values[codexApprovalKey] == codexApprovalBypass && values[codexSandboxKey] == codexSandboxBypass {
+		return codexBypassStatusValue, nil
+	}
+	return "", nil
+}
+
+// --- minimal TOML helpers ---
+//
+// cvm only needs to set/get a handful of top-level scalar keys in
+// config.toml. Pulling in BurntSushi/toml just for that would be overkill,
+// so we operate line-by-line and only touch the top-level table (i.e. the
+// region before the first [section] header). All other content — comments,
+// whitespace, sub-tables — is preserved verbatim.
+
+// setCodexTopLevelKeys ensures each key in `pairs` is set to the given raw
+// TOML value within the top-level table of `path`. Existing top-level keys
+// are replaced in place; missing ones are appended just before the first
+// section header (or at end-of-file). Values must already be TOML-encoded
+// (e.g. quoted strings).
+func setCodexTopLevelKeys(path string, pairs map[string]string) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	lines := splitLines(data)
+	remaining := map[string]string{}
+	for k, v := range pairs {
+		remaining[k] = v
+	}
+
+	sectionStart := -1 // index of first line that opens a section header
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if sectionStart == -1 && isTOMLSectionHeader(trimmed) {
+			sectionStart = i
+			break
+		}
+		key, ok := topLevelKeyName(trimmed)
+		if !ok {
+			continue
+		}
+		if val, want := remaining[key]; want {
+			lines[i] = fmt.Sprintf("%s = %s", key, val)
+			delete(remaining, key)
+		}
+	}
+
+	if len(remaining) > 0 {
+		// Append in deterministic order so test output is stable.
+		ordered := orderedKeys(remaining)
+		insert := make([]string, 0, len(ordered))
+		for _, k := range ordered {
+			insert = append(insert, fmt.Sprintf("%s = %s", k, remaining[k]))
+		}
+
+		if sectionStart == -1 {
+			// No sections — append at end, ensuring a trailing newline.
+			lines = append(lines, insert...)
+		} else {
+			// Insert just before the section header, with a separating blank
+			// line if the preceding line is non-empty.
+			prefix := lines[:sectionStart]
+			if len(prefix) > 0 && strings.TrimSpace(prefix[len(prefix)-1]) != "" {
+				insert = append([]string{""}, insert...)
+			}
+			insert = append(insert, "")
+			combined := append([]string{}, prefix...)
+			combined = append(combined, insert...)
+			combined = append(combined, lines[sectionStart:]...)
+			lines = combined
+		}
+	}
+
+	out := strings.Join(lines, "\n")
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return os.WriteFile(path, []byte(out), 0644)
+}
+
+// removeCodexTopLevelKeys removes any top-level lines whose key matches one
+// of `keys`. If the file becomes empty (or only whitespace) it is deleted.
+func removeCodexTopLevelKeys(path string, keys []string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	wanted := map[string]struct{}{}
+	for _, k := range keys {
+		wanted[k] = struct{}{}
+	}
+
+	lines := splitLines(data)
+	out := make([]string, 0, len(lines))
+	inSection := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isTOMLSectionHeader(trimmed) {
+			inSection = true
+			out = append(out, line)
+			continue
+		}
+		if !inSection {
+			if key, ok := topLevelKeyName(trimmed); ok {
+				if _, drop := wanted[key]; drop {
+					continue
+				}
+			}
+		}
+		out = append(out, line)
+	}
+
+	joined := strings.Join(out, "\n")
+	if strings.TrimSpace(joined) == "" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	if !strings.HasSuffix(joined, "\n") {
+		joined += "\n"
+	}
+	return os.WriteFile(path, []byte(joined), 0644)
+}
+
+// readCodexTopLevelKeys returns the raw decoded string values for the given
+// top-level keys. Keys that aren't present, aren't strings, or live inside a
+// section header are simply absent from the result map.
+func readCodexTopLevelKeys(path string, keys []string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	wanted := map[string]struct{}{}
+	for _, k := range keys {
+		wanted[k] = struct{}{}
+	}
+
+	out := map[string]string{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
+	for scanner.Scan() {
+		trimmed := strings.TrimSpace(scanner.Text())
+		if isTOMLSectionHeader(trimmed) {
+			break
+		}
+		key, ok := topLevelKeyName(trimmed)
+		if !ok {
+			continue
+		}
+		if _, want := wanted[key]; !want {
+			continue
+		}
+		eq := strings.Index(trimmed, "=")
+		if eq < 0 {
+			continue
+		}
+		raw := strings.TrimSpace(trimmed[eq+1:])
+		raw = stripInlineComment(raw)
+		if v, ok := unquoteTOMLString(raw); ok {
+			out[key] = v
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// isTOMLSectionHeader detects a `[section]` or `[[array.of.tables]]` line.
+func isTOMLSectionHeader(trimmed string) bool {
+	if strings.HasPrefix(trimmed, "#") {
+		return false
+	}
+	return strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]")
+}
+
+// topLevelKeyName returns the key name of a `key = value` line, or false if
+// the line is empty, a comment, or doesn't look like an assignment. Quoted
+// keys are returned with surrounding quotes stripped.
+func topLevelKeyName(trimmed string) (string, bool) {
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return "", false
+	}
+	eq := strings.Index(trimmed, "=")
+	if eq <= 0 {
+		return "", false
+	}
+	key := strings.TrimSpace(trimmed[:eq])
+	if key == "" {
+		return "", false
+	}
+	if strings.ContainsAny(key, ".[]") {
+		return "", false // dotted/bracketed keys are out of scope here
+	}
+	if (strings.HasPrefix(key, "\"") && strings.HasSuffix(key, "\"")) ||
+		(strings.HasPrefix(key, "'") && strings.HasSuffix(key, "'")) {
+		key = key[1 : len(key)-1]
+	}
+	return key, true
+}
+
+// quoteTOMLString returns a TOML basic-string literal for the given value.
+// It only handles the small subset of escapes we actually emit (none of our
+// bypass values contain quotes or backslashes), so the implementation stays
+// compact and audit-friendly.
+func quoteTOMLString(s string) string {
+	return "\"" + strings.NewReplacer("\\", "\\\\", "\"", "\\\"").Replace(s) + "\""
+}
+
+// unquoteTOMLString accepts a basic ("...") or literal ('...') string and
+// returns its contents. Returns ok=false for any other shape (numbers,
+// arrays, inline tables, multiline strings).
+func unquoteTOMLString(raw string) (string, bool) {
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		// Reverse the simple escapes we emit.
+		inner := raw[1 : len(raw)-1]
+		inner = strings.NewReplacer("\\\"", "\"", "\\\\", "\\").Replace(inner)
+		return inner, true
+	}
+	if len(raw) >= 2 && raw[0] == '\'' && raw[len(raw)-1] == '\'' {
+		return raw[1 : len(raw)-1], true
+	}
+	return "", false
+}
+
+// stripInlineComment removes a trailing `# comment` from a TOML value, but
+// only when the `#` is outside of any string literal we recognize.
+func stripInlineComment(raw string) string {
+	inDouble, inSingle := false, false
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		switch {
+		case c == '\\' && inDouble && i+1 < len(raw):
+			i++ // skip escaped char inside basic string
+		case c == '"' && !inSingle:
+			inDouble = !inDouble
+		case c == '\'' && !inDouble:
+			inSingle = !inSingle
+		case c == '#' && !inDouble && !inSingle:
+			return strings.TrimSpace(raw[:i])
+		}
+	}
+	return raw
+}
+
+func splitLines(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	s := string(data)
+	// Strip a single trailing newline so we don't introduce an empty trailing
+	// line when joining back; we'll re-add it on write.
+	s = strings.TrimRight(s, "\n")
+	return strings.Split(s, "\n")
+}
+
+func orderedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// Simple deterministic order: bypass writes only ever pass two known
+	// keys, but sort anyway so tests don't depend on map iteration.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -28,6 +28,17 @@ type Harness interface {
 	SupportsPortableAgents() bool
 	IsUserMCPPath(profilePath string) bool
 	IsMCPPath(profilePath string) bool
+
+	// EnableBypass puts the harness into "bypass permissions" mode for the
+	// given active profile. Implementations decide whether the change is
+	// persisted as a profile override (so it survives `cvm pull`) or written
+	// directly to the live config dir.
+	EnableBypass(profileName string) error
+	// DisableBypass restores the harness to its default permissions mode.
+	DisableBypass(profileName string) error
+	// BypassStatus returns a short human-readable status of the current
+	// bypass state ("" or "(default)" means "not bypassed").
+	BypassStatus(profileName string) (string, error)
 }
 
 func ManagedProfileItems(h Harness) []string {

--- a/internal/harness/opencode.go
+++ b/internal/harness/opencode.go
@@ -1,10 +1,18 @@
 package harness
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/chichex/cvm/internal/config"
 )
+
+// opencodeBypassValue is the global "allow" shorthand documented at
+// https://opencode.ai/docs/permissions/. Setting permission to the literal
+// string "allow" disables every approval prompt.
+const opencodeBypassValue = "allow"
 
 type opencodeHarness struct{}
 
@@ -81,4 +89,101 @@ func (opencodeHarness) IsUserMCPPath(profilePath string) bool {
 
 func (opencodeHarness) IsMCPPath(profilePath string) bool {
 	return profilePath == "opencode.json"
+}
+
+// EnableBypass writes the OpenCode bypass permission block to the profile's
+// override opencode.json. opencode.json is a managed item, so reapply merges
+// the override into ~/.config/opencode/opencode.json.
+func (opencodeHarness) EnableBypass(profileName string) error {
+	overrideDir := config.OverrideDir(profileName)
+	overridePath := filepath.Join(overrideDir, "opencode.json")
+	cfg, err := readOpenCodeJSON(overridePath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	cfg["permission"] = opencodeBypassValue
+	if err := os.MkdirAll(overrideDir, 0755); err != nil {
+		return err
+	}
+	return writeOpenCodeJSON(overridePath, cfg)
+}
+
+// DisableBypass removes the bypass permission key from the profile's override
+// opencode.json (and removes the file entirely if it becomes empty).
+func (opencodeHarness) DisableBypass(profileName string) error {
+	overridePath := filepath.Join(config.OverrideDir(profileName), "opencode.json")
+	cfg, err := readOpenCodeJSON(overridePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if _, ok := cfg["permission"]; !ok {
+		return nil
+	}
+	delete(cfg, "permission")
+	if len(cfg) == 0 {
+		if err := os.Remove(overridePath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	return writeOpenCodeJSON(overridePath, cfg)
+}
+
+// BypassStatus reports the current permission value persisted in the
+// profile's override opencode.json.
+func (opencodeHarness) BypassStatus(profileName string) (string, error) {
+	overridePath := filepath.Join(config.OverrideDir(profileName), "opencode.json")
+	cfg, err := readOpenCodeJSON(overridePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	switch v := cfg["permission"].(type) {
+	case string:
+		return v, nil
+	case map[string]any:
+		// Pretty-print object form as e.g. "{bash: allow, edit: ask}".
+		// Status only needs to convey "non-default", not full content.
+		if len(v) == 0 {
+			return "", nil
+		}
+		return "custom", nil
+	default:
+		return "", nil
+	}
+}
+
+func readOpenCodeJSON(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	cfg := map[string]any{}
+	if len(data) == 0 {
+		return cfg, nil
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func writeOpenCodeJSON(path string, cfg map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0644)
 }

--- a/internal/profile/vanilla_test.go
+++ b/internal/profile/vanilla_test.go
@@ -62,6 +62,18 @@ func (h testHarness) IsMCPPath(profilePath string) bool {
 	return false
 }
 
+func (h testHarness) EnableBypass(profileName string) error {
+	return nil
+}
+
+func (h testHarness) DisableBypass(profileName string) error {
+	return nil
+}
+
+func (h testHarness) BypassStatus(profileName string) (string, error) {
+	return "", nil
+}
+
 func TestVanillaBackupIsScopedByHarness(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/profiles/portable/opencode/AGENTS.md
+++ b/profiles/portable/opencode/AGENTS.md
@@ -19,6 +19,20 @@ Profile orientado a definir specs portables y reutilizables a partir de historia
 | `portable-code-executor` | Implementa pasos de un plan (`.portable/plans/<N>-<slug>.md`) sobre la branch del PR. Antes de empezar carga contexto rico del PR (body, comments, reviews, review comments line-level, ultimo feedback del validator, spec issue body). Build/typecheck minimo + 1-3 unit tests acotados. Commit + push. Sin WebFetch/WebSearch. |
 | `portable-code-validator` | Valida un PR de plan: carga contexto del PR (mismo set que el executor), espera `gh pr checks`, corre suite completa local, contrasta diff vs cada paso/archivo/riesgo del plan. Emite verdict PASS/FAIL + feedback accionable. Sin Edit/Write. |
 
+## Modelo de ejecucion OpenCode
+
+Los 5 workflows se ejecutan como **skills primarios**. Solo las partes autonomas de implementacion y validacion se delegan a subagents.
+
+| Workflow | Entry point primario | Delegacion a subagent |
+|----------|----------------------|------------------------|
+| Spec | `/portable-spec` | No. Interactivo multi-turno en el orquestador principal. |
+| Plan | `/portable-plan` | No. Interactivo multi-turno en el orquestador principal. |
+| Exec | `/portable-code-exec` | Si, delega a `portable-code-executor`. |
+| Validate | `/portable-code-validate` | Si, delega a `portable-code-validator`. |
+| Loop | `/portable-code-loop` | Si, orquesta `portable-code-executor` y `portable-code-validator`. |
+
+No crear subagents separados para `/portable-spec` o `/portable-plan` salvo que el flujo deje de ser interactivo. Esos skills necesitan refinar asunciones con el usuario antes de persistir issue/PR.
+
 ## Labels de estado (aplicados por los skills `/portable-code-*`)
 
 | Label | Significado | Aplicado por |


### PR DESCRIPTION
## Summary

- Bypass enable/disable/status are now per-harness behind `Harness.EnableBypass / DisableBypass / BypassStatus`, so `cvm bypass` works for OpenCode and Codex in addition to Claude.
- Claude's wire format is unchanged: same `permissions.defaultMode = bypassPermissions` + `allow[]` block, still written to the profile's override `settings.json` and applied via `Reapply`. The existing `TestBypassCommand` e2e passes untouched.
- OpenCode writes the global `"permission": "allow"` shorthand (per [opencode.ai/docs/permissions](https://opencode.ai/docs/permissions/)) into the profile's override `opencode.json`. Since `opencode.json` is already a managed item, `Reapply` merges it into `~/.config/opencode/opencode.json` and survives `cvm pull`.
- Codex sets `approval_policy = "never"` + `sandbox_mode = "danger-full-access"` directly in `~/.codex/config.toml` (per [developers.openai.com/codex/config-reference](https://developers.openai.com/codex/config-reference)). `config.toml` is not in `ManagedDirItems`, so we write live with a small line-based TOML helper that preserves existing comments / unrelated keys / sub-tables. No external TOML dependency added.
- `cvm bypass` keeps zero-arg ergonomics. Without `--harness` it iterates every harness with an active profile; `--harness {claude|opencode|codex}` scopes to one.

## Design notes

- **Interface, not free function.** Each harness owns its bypass shape; the `cmd/` layer is now a thin dispatcher.
- **Override vs live.** Claude and OpenCode persist into the profile override dir (survives `cvm pull`). Codex writes to live `config.toml` because cvm has no TOML override-merge semantics yet — captured as a known limitation, see "Risks / pendientes" below.
- **Minimal TOML.** Inline helpers operate only on top-level scalar keys (everything before the first `[section]`), strip inline comments outside string literals, and round-trip basic / literal strings. Stays compact and audit-friendly; no `BurntSushi/toml` dep.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages green, including the existing `TestBypassCommand` e2e
- [x] New `internal/harness/bypass_test.go` covering, per harness:
  - enable writes the expected file/keys
  - disable strips them
  - status reports correct state
  - non-existent override / config is a no-op
  - unrelated keys / comments / sub-tables in pre-existing files are preserved (codex round-trip explicitly asserted)

## Breaking changes

None observable. Output format for `cvm bypass` adds a `<harness> ` prefix to each line (e.g. `claude profile "work": bypassPermissions`), but the existing assertion in `TestBypassCommand` keeps passing because `profile "<name>"` and `bypassPermissions` are still substrings.

## Risks / pendientes

- Codex bypass is not stored in the override dir, so `cvm pull` won't unset it but also won't re-apply it after `cvm use --none`. Once cvm grows a TOML merge layer for codex managed items, this can move into the override pipeline like Claude/OpenCode.