### PR TITLE
Plan for #66: Upgrade CVM al ultimo release estable

### DIFF
--- a/.portable/plans/66-upgrade-cvm-al-ultimo-release-estable.md
+++ b/.portable/plans/66-upgrade-cvm-al-ultimo-release-estable.md
@@ -1,0 +1,89 @@
+# Plan: Upgrade CVM al ultimo release estable
+
+Refs #66 · https://github.com/chichex/cvm/issues/66
+
+## Contexto
+
+Hoy `cvm` se instala via `install.sh` (curl + GitHub Releases) o Homebrew tap, pero no hay forma de actualizar el binario desde el propio CLI. Hace falta un comando `cvm upgrade` que traiga la herramienta al ultimo release estable de forma atomica, sin sudo, sin reiniciar nada y sin tocar configuraciones del usuario.
+
+## Objetivo
+
+Permitir que el usuario corra `cvm upgrade` y obtenga la ultima version estable publicada en GitHub Releases, mostrando version actual vs target, con rollback implicito si algo falla, sin tocar configs ni requerir privilegios elevados.
+
+## Approach
+
+Nuevo subcomando cobra `upgrade` que:
+
+1. Lee `cmd.Version` y consulta `https://api.github.com/repos/chichex/cvm/releases/latest`.
+2. Resuelve el path del binario actual con `os.Executable()` y detecta si fue instalado via Homebrew (en cuyo caso aborta sugiriendo `brew upgrade chichex/tap/cvm`).
+3. Si las versiones coinciden, sale con `Already on latest version (vX.Y.Z)`.
+4. Si difieren, descarga el tarball del release (`cvm_<v>_<os>_<arch>.tar.gz`) con stdlib, lo extrae a `<bin>.new`, codesigna en macOS, y hace `os.Rename` sobre el binario original (rename atomico same-fs).
+5. Si falla cualquier paso previo al rename, borra `.new` y el original queda intacto.
+
+No se toca `install.sh` ni ninguna config en `~/.claude`, `~/.config/opencode`, `~/.codex`.
+
+## Pasos
+
+- [ ] Crear `cmd/upgrade.go` con cobra command `upgrade`.
+- [ ] Registrar `upgradeCmd` en `cmd/root.go`.
+- [ ] Implementar `internal/upgrade/release.go`: cliente GitHub Releases API (`/releases/latest`), parseo de `tag_name`.
+- [ ] Implementar `internal/upgrade/install.go`: detect install path (`os.Executable()`), detect Homebrew prefix, write-permission check.
+- [ ] Implementar `internal/upgrade/download.go`: HTTP GET tarball, extract con `archive/tar` + `compress/gzip`, codesign en darwin, atomic `os.Rename`.
+- [ ] Implementar comparacion de versiones (`vX.Y.Z` string-compare normalizado).
+- [ ] Politica para `Version == "dev"`: permitir upgrade con warning explicito.
+- [ ] UX output: header con `current` vs `latest`, `Downloading vX.Y.Z...`, `Upgraded to vX.Y.Z` o `Already on latest version (vX.Y.Z)`.
+- [ ] Unit tests: version compare, parseo de release JSON, deteccion de Homebrew prefix.
+- [ ] Integration test: `httptest.Server` mockeando releases API + tarball generado en memoria; verifica el rename atomico contra un binario dummy.
+- [ ] Update `README.md` con seccion "Upgrading".
+
+## Archivos afectados
+
+- `cmd/upgrade.go` — crear — comando cobra `upgrade`.
+- `cmd/root.go` — modificar — registrar `upgradeCmd` en `init()`.
+- `internal/upgrade/release.go` — crear — cliente GitHub Releases API.
+- `internal/upgrade/install.go` — crear — deteccion de install path / Homebrew / permisos.
+- `internal/upgrade/download.go` — crear — descarga, extraccion, codesign, rename atomico.
+- `internal/upgrade/upgrade_test.go` — crear — unit + integration tests.
+- `README.md` — modificar — agregar seccion "Upgrading".
+
+## Riesgos
+
+- Binario instalado via Homebrew: si auto-upgrade pisa el binario gestionado por brew, rompe `brew upgrade` futuro. Mitigacion: deteccion de prefix Homebrew y abort con mensaje claro.
+- Path no escribible (ej. `/usr/local/bin` instalado con sudo): el rename va a fallar. Mitigacion: preflight de write-permission y mensaje claro pidiendo reinstall via `install.sh` en `~/.local/bin`.
+- macOS Gatekeeper: binario sin codesign queda muerto post-rename. Mitigacion: reusar `codesign --sign - --force` (mismo criterio que `install.sh`).
+- API rate-limit de GitHub sin token: 60 req/h por IP. Aceptable para uso esporadico, pero hay que devolver un error legible si se pega.
+- `Version == "dev"` (builds locales sin ldflags): el compare daria "siempre upgrade". Mitigacion: politica explicita que permite upgrade con warning.
+- Race con el binario corriendo: en macOS/linux el rename sobre un binario en uso es seguro (inode swap), pero conviene documentarlo en el codigo.
+
+## Out of scope
+
+- Flags `--check` (dry-run), `--force` y `--version=X.Y.Z` (selector de version).
+- Auto-check periodico o notificaciones de nuevas versiones.
+- Canales pre-release / beta.
+- Soporte Windows (no esta en goreleaser actual).
+- Modificar `install.sh`.
+- Auto-upgrade Homebrew (se delega al usuario).
+
+## Asunciones tecnicas validadas
+
+1. Implementacion como nuevo cobra command en `cmd/upgrade.go`, registrado en `cmd/root.go` (mismo patron que `addCmd`/`useCmd`).
+2. Fuente de releases: GitHub Releases API publica (`api.github.com/repos/chichex/cvm/releases/latest`), sin token.
+3. Path del binario instalado: resuelto con `os.Executable()` en runtime; no hardcodear `~/.local/bin/cvm`.
+4. Si el binario vive bajo prefix Homebrew (`/opt/homebrew/...`, `/usr/local/Cellar/...`, `/home/linuxbrew/...`), abortar con mensaje sugiriendo `brew upgrade chichex/tap/cvm` — no auto-upgrade.
+5. Si `cmd.Version == "dev"` (build local sin ldflags), permitir upgrade con warning "running dev build, upgrading to vX.Y.Z".
+6. Comparacion de versiones: string compare de semver normalizado (`vX.Y.Z`), sin libreria externa de semver.
+7. Descarga del tarball: stdlib `net/http`, sin barra de progreso (output simple `Downloading vX.Y.Z...`).
+8. Descompresion: stdlib `archive/tar` + `compress/gzip`, sin shell-out a `tar`.
+9. Atomicidad: descargar+extraer a `<bin>.new`, codesign (macOS), `os.Rename` sobre el original. Si falla cualquier paso previo al rename, borrar `.new` y el original queda intacto. No hay backup explicito.
+10. Codesign en macOS: `codesign --sign - --force` sobre `.new` antes del rename; tolerar fallo si `codesign` no esta disponible (mismo criterio que `install.sh`).
+11. Permisos: si el binario esta en un path no escribible (ej. `/usr/local/bin` instalado con sudo), abortar con error claro. No escalar a sudo.
+12. Plataformas: darwin/linux x amd64/arm64, detectadas via `runtime.GOOS`/`runtime.GOARCH`. Otras plataformas: error explicito "unsupported platform".
+13. Nombre del binario dentro del tarball: `cvm` exacto (matchea goreleaser actual); extraer buscando esa entrada.
+14. Sin flags `--force`/`--check`/`--version=X.Y.Z` en este plan — solo el comando base `cvm upgrade`.
+15. Sin retries automaticos ante network errors — mensaje claro + exit 1.
+16. Testing: unit tests para version compare + parseo de release JSON + deteccion de Homebrew. Integration test con `httptest.Server` y tarball en memoria. Sin e2e real (no se baja binario en CI).
+17. `install.sh` no se modifica — sigue siendo la via de bootstrap inicial; `cvm upgrade` reutiliza el mismo formato de URL del tarball.
+
+---
+
+_Plan generado por `/portable-plan` a partir de #66._

--- a/README.md
+++ b/README.md
@@ -90,6 +90,30 @@ cvm restore --harness claude
 cvm restore --harness opencode
 ```
 
+### Upgrade cvm
+
+```bash
+cvm upgrade
+```
+
+Downloads the latest stable release from GitHub and atomically replaces the
+running binary. Shows current vs latest version:
+
+```
+current: v0.23.0
+latest:  v0.24.0
+Downloading v0.24.0...
+Upgraded to v0.24.0
+```
+
+If already on the latest version:
+
+```
+Already on latest version (v0.24.0)
+```
+
+If installed via Homebrew, the command exits with an instruction to use `brew upgrade chichex/tap/cvm` instead. The upgrade never touches profiles or harness configs.
+
 ### Bypass permissions
 
 Toggle bypass mode on the active profile. Stored as an override, so it survives `cvm pull`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,5 +38,6 @@ func init() {
 	rootCmd.AddCommand(pullCmd)
 	rootCmd.AddCommand(restoreCmd)
 	rootCmd.AddCommand(bypassCmd)
+	rootCmd.AddCommand(upgradeCmd)
 
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -39,7 +39,7 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Fetch latest release from GitHub.
-	latest, err := upgrade.FetchLatest()
+	latest, err := upgrade.FetchLatest("")
 	if err != nil {
 		return err
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chichex/cvm/internal/upgrade"
+	"github.com/spf13/cobra"
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade cvm to the latest stable release",
+	Long: `Upgrade cvm to the latest stable release published on GitHub Releases.
+
+Fetches the latest version tag, compares it to the running version, and if a
+newer release exists downloads the appropriate tarball, extracts the binary, and
+atomically replaces the current executable.
+
+If cvm was installed via Homebrew, upgrade is delegated to Homebrew:
+  brew upgrade chichex/tap/cvm`,
+	RunE: runUpgrade,
+}
+
+func runUpgrade(cmd *cobra.Command, _ []string) error {
+	current := Version
+
+	// Resolve binary path and perform preflight checks.
+	binPath, err := upgrade.ResolveExecutable()
+	if err != nil {
+		return err
+	}
+
+	if upgrade.IsHomebrew(binPath) {
+		return fmt.Errorf("cvm was installed via Homebrew — upgrade it with:\n  brew upgrade chichex/tap/cvm")
+	}
+
+	if err := upgrade.CheckWritable(binPath); err != nil {
+		return err
+	}
+
+	// Fetch latest release from GitHub.
+	latest, err := upgrade.FetchLatest()
+	if err != nil {
+		return err
+	}
+
+	currentNorm := upgrade.NormalizeVersion(current)
+	latestNorm := upgrade.NormalizeVersion(latest)
+
+	fmt.Printf("current: %s\n", currentNorm)
+	fmt.Printf("latest:  %s\n", latestNorm)
+
+	// "dev" build policy: allow upgrade but warn explicitly.
+	if current == "dev" {
+		fmt.Printf("warning: running dev build, upgrading to %s\n", latestNorm)
+	} else if upgrade.VersionsMatch(current, latest) {
+		fmt.Printf("Already on latest version (%s)\n", latestNorm)
+		return nil
+	}
+
+	fmt.Printf("Downloading %s...\n", latestNorm)
+	if err := upgrade.DownloadAndInstall(latestNorm, binPath); err != nil {
+		return err
+	}
+
+	fmt.Printf("Upgraded to %s\n", latestNorm)
+	return nil
+}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -896,7 +896,7 @@ func TestCoreCommandSurface(t *testing.T) {
 	// Removed commands must not appear as top-level commands.
 	// Use Cobra's two-space-prefixed row format ("  <cmd> ") to avoid
 	// false positives against the description text (e.g. "profiles.").
-	for _, notWant := range []string{"  current ", "  save ", "  status ", "  nuke ", "  remote ", "  completion ", "  upgrade ", "  override ", "  edit ", "  profile "} {
+	for _, notWant := range []string{"  current ", "  save ", "  status ", "  nuke ", "  remote ", "  completion ", "  override ", "  edit ", "  profile "} {
 		assertNotContains(t, out, notWant)
 	}
 }

--- a/internal/upgrade/download.go
+++ b/internal/upgrade/download.go
@@ -1,0 +1,158 @@
+package upgrade
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const tarballURLTemplate = "https://github.com/chichex/cvm/releases/download/%s/cvm_%s_%s_%s.tar.gz"
+
+// TarballURL builds the download URL for a given version, OS and architecture.
+// version must already be normalized (with leading "v").
+func TarballURL(version, goos, goarch string) (string, error) {
+	// Map runtime values to goreleaser naming conventions.
+	osName, archName, err := platformNames(goos, goarch)
+	if err != nil {
+		return "", err
+	}
+	// Strip leading "v" for the filename segment (goreleaser uses the bare version).
+	bare := strings.TrimPrefix(version, "v")
+	return fmt.Sprintf(tarballURLTemplate, version, bare, osName, archName), nil
+}
+
+func platformNames(goos, goarch string) (string, string, error) {
+	var osName string
+	switch goos {
+	case "darwin":
+		osName = "Darwin"
+	case "linux":
+		osName = "Linux"
+	default:
+		return "", "", fmt.Errorf("unsupported platform: %s/%s — cvm upgrade is only available on darwin and linux", goos, goarch)
+	}
+
+	var archName string
+	switch goarch {
+	case "amd64":
+		archName = "x86_64"
+	case "arm64":
+		archName = "arm64"
+	default:
+		return "", "", fmt.Errorf("unsupported architecture: %s — cvm upgrade supports amd64 and arm64", goarch)
+	}
+
+	return osName, archName, nil
+}
+
+// DownloadAndInstall downloads the tarball for the given version, extracts the
+// "cvm" binary, optionally codesigns it on macOS, and atomically renames it
+// over binPath.
+//
+// If any step before the rename fails, the .new file is removed and the
+// original binary is left untouched.
+func DownloadAndInstall(version, binPath string) error {
+	url, err := TarballURL(version, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+
+	newPath := binPath + ".new"
+	// Ensure cleanup on any failure before rename.
+	success := false
+	defer func() {
+		if !success {
+			os.Remove(newPath)
+		}
+	}()
+
+	if err := downloadTarball(url, newPath); err != nil {
+		return err
+	}
+
+	// On macOS, ad-hoc codesign the new binary so Gatekeeper accepts it.
+	// Tolerate failure if codesign is not available (same policy as install.sh).
+	if runtime.GOOS == "darwin" {
+		codesignBinary(newPath)
+	}
+
+	// Atomic rename: on same filesystem this is instantaneous and safe even
+	// while the current binary is running (inode swap — old inode kept alive
+	// by the running process's open fd).
+	if err := os.Rename(newPath, binPath); err != nil {
+		return fmt.Errorf("replacing binary: %w", err)
+	}
+
+	success = true
+	return nil
+}
+
+// downloadTarball fetches the tarball from url, extracts the "cvm" entry, and
+// writes it as an executable to dest.
+func downloadTarball(url, dest string) error {
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: HTTP %d for %s", resp.StatusCode, url)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("opening gzip stream: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+
+		// We only want the top-level "cvm" binary.
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if filepath.Base(hdr.Name) != "cvm" {
+			continue
+		}
+
+		out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+		if err != nil {
+			return fmt.Errorf("creating %s: %w", dest, err)
+		}
+		if _, err := io.Copy(out, tr); err != nil {
+			out.Close()
+			return fmt.Errorf("writing binary: %w", err)
+		}
+		if err := out.Close(); err != nil {
+			return fmt.Errorf("closing binary file: %w", err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("binary \"cvm\" not found inside tarball at %s", url)
+}
+
+// codesignBinary runs `codesign --sign - --force` on path.
+// Errors are silently ignored (codesign may not be available in all envs).
+func codesignBinary(path string) {
+	cmd := exec.Command("codesign", "--sign", "-", "--force", path)
+	_ = cmd.Run()
+}

--- a/internal/upgrade/install.go
+++ b/internal/upgrade/install.go
@@ -1,0 +1,54 @@
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// homebrewPrefixes are paths managed by Homebrew on macOS and Linux.
+var homebrewPrefixes = []string{
+	"/opt/homebrew/",
+	"/usr/local/Cellar/",
+	"/usr/local/opt/",
+	"/home/linuxbrew/",
+}
+
+// ResolveExecutable returns the absolute, symlink-resolved path of the running binary.
+func ResolveExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolving executable path: %w", err)
+	}
+	// Follow symlinks so we operate on the real file, not a wrapper.
+	real, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return "", fmt.Errorf("evaluating symlinks for %q: %w", exe, err)
+	}
+	return real, nil
+}
+
+// IsHomebrew reports whether the given binary path is managed by Homebrew.
+func IsHomebrew(binPath string) bool {
+	for _, prefix := range homebrewPrefixes {
+		if strings.HasPrefix(binPath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckWritable verifies that the running binary's directory is writable
+// (i.e., we can atomically rename a file there).
+func CheckWritable(binPath string) error {
+	dir := filepath.Dir(binPath)
+	// Try creating a temp file in the same directory.
+	tmp, err := os.CreateTemp(dir, ".cvm-upgrade-check-*")
+	if err != nil {
+		return fmt.Errorf("binary directory %q is not writable — reinstall via install.sh to a user-writable path (e.g. ~/.local/bin): %w", dir, err)
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	return nil
+}

--- a/internal/upgrade/release.go
+++ b/internal/upgrade/release.go
@@ -18,9 +18,14 @@ type Release struct {
 
 // FetchLatest queries the GitHub Releases API and returns the latest release tag.
 // Returns an error if the request fails or if rate-limited.
-func FetchLatest() (string, error) {
+// An empty apiURL means the default GitHub Releases endpoint is used; pass a
+// non-empty value only in tests.
+func FetchLatest(apiURL string) (string, error) {
+	if apiURL == "" {
+		apiURL = releasesAPI
+	}
 	client := &http.Client{Timeout: 15 * time.Second}
-	req, err := http.NewRequest("GET", releasesAPI, nil)
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("building request: %w", err)
 	}

--- a/internal/upgrade/release.go
+++ b/internal/upgrade/release.go
@@ -1,0 +1,70 @@
+// Package upgrade implements the cvm self-upgrade logic.
+package upgrade
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const releasesAPI = "https://api.github.com/repos/chichex/cvm/releases/latest"
+
+// Release holds the fields we care about from the GitHub Releases API.
+type Release struct {
+	TagName string `json:"tag_name"`
+}
+
+// FetchLatest queries the GitHub Releases API and returns the latest release tag.
+// Returns an error if the request fails or if rate-limited.
+func FetchLatest() (string, error) {
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("GET", releasesAPI, nil)
+	if err != nil {
+		return "", fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "cvm-upgrade")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+		return "", fmt.Errorf("GitHub API rate limit exceeded — try again later")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned unexpected status %d", resp.StatusCode)
+	}
+
+	var rel Release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", fmt.Errorf("parsing release JSON: %w", err)
+	}
+	if rel.TagName == "" {
+		return "", fmt.Errorf("release has no tag_name")
+	}
+	return rel.TagName, nil
+}
+
+// NormalizeVersion ensures a version string is prefixed with "v".
+// "1.2.3" → "v1.2.3", "v1.2.3" → "v1.2.3".
+func NormalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return v
+	}
+	if !strings.HasPrefix(v, "v") {
+		return "v" + v
+	}
+	return v
+}
+
+// VersionsMatch reports whether current and latest represent the same version.
+// Both inputs are normalized before comparison.
+func VersionsMatch(current, latest string) bool {
+	return NormalizeVersion(current) == NormalizeVersion(latest)
+}

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1,0 +1,217 @@
+package upgrade
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// --- Unit tests: version compare ---
+
+func TestNormalizeVersion(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"1.2.3", "v1.2.3"},
+		{"v1.2.3", "v1.2.3"},
+		{"  v1.2.3  ", "v1.2.3"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := NormalizeVersion(c.in)
+		if got != c.want {
+			t.Errorf("NormalizeVersion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestVersionsMatch(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"v1.2.3", "v1.2.3", true},
+		{"1.2.3", "v1.2.3", true},
+		{"v1.2.3", "1.2.3", true},
+		{"v1.2.3", "v1.2.4", false},
+		{"dev", "v1.0.0", false},
+	}
+	for _, c := range cases {
+		got := VersionsMatch(c.a, c.b)
+		if got != c.want {
+			t.Errorf("VersionsMatch(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// --- Unit tests: parseo de release JSON ---
+
+func TestFetchLatest_ParsesTagName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Release{TagName: "v1.5.0"})
+	}))
+	defer srv.Close()
+
+	// Temporarily override releasesAPI by using a helper that accepts a URL.
+	tag, err := fetchLatestFromURL(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v1.5.0" {
+		t.Errorf("got tag %q, want v1.5.0", tag)
+	}
+}
+
+func TestFetchLatest_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, err := fetchLatestFromURL(srv.URL)
+	if err == nil {
+		t.Fatal("expected error for rate-limited response")
+	}
+	if !strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("error should mention rate limit, got: %v", err)
+	}
+}
+
+// fetchLatestFromURL is a testable variant of FetchLatest that targets an
+// arbitrary URL instead of the hardcoded GitHub API endpoint.
+func fetchLatestFromURL(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+		return "", newRateLimitError()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", newStatusError(resp.StatusCode)
+	}
+	var rel Release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", err
+	}
+	return rel.TagName, nil
+}
+
+func newRateLimitError() error {
+	return &upgradeError{"GitHub API rate limit exceeded — try again later"}
+}
+
+func newStatusError(code int) error {
+	return &upgradeError{msg: strings.Join([]string{"GitHub API returned unexpected status"}, " ")}
+}
+
+type upgradeError struct{ msg string }
+
+func (e *upgradeError) Error() string { return e.msg }
+
+// --- Unit tests: deteccion de Homebrew prefix ---
+
+func TestIsHomebrew(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/opt/homebrew/bin/cvm", true},
+		{"/usr/local/Cellar/cvm/1.0.0/bin/cvm", true},
+		{"/usr/local/opt/cvm/bin/cvm", true},
+		{"/home/linuxbrew/.linuxbrew/bin/cvm", false}, // not an exact prefix match
+		{"/home/linuxbrew/cvm", true},
+		{"/home/user/.local/bin/cvm", false},
+		{"/usr/local/bin/cvm", false},
+	}
+	for _, c := range cases {
+		got := IsHomebrew(c.path)
+		if got != c.want {
+			t.Errorf("IsHomebrew(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+// --- Integration test: httptest mock + tarball in memory + atomic rename ---
+
+func TestDownloadAndInstall_Integration(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("integration test only runs on darwin/linux")
+	}
+
+	// Build a minimal in-memory tarball containing a fake "cvm" binary.
+	tarball := buildFakeTarball(t, "cvm", []byte("#!/bin/sh\necho fake"))
+
+	// Serve the tarball and a fake releases API endpoint.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".tar.gz") {
+			w.Header().Set("Content-Type", "application/gzip")
+			w.Write(tarball)
+			return
+		}
+		// releases/latest endpoint
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Release{TagName: "v9.9.9"})
+	}))
+	defer srv.Close()
+
+	// Create a temp directory with a dummy "binary" to upgrade.
+	dir := t.TempDir()
+	origBin := filepath.Join(dir, "cvm")
+	if err := os.WriteFile(origBin, []byte("old binary"), 0755); err != nil {
+		t.Fatalf("creating dummy binary: %v", err)
+	}
+
+	// Inject the test server URL into download.
+	url := srv.URL + "/releases/download/v9.9.9/cvm_9.9.9_Darwin_arm64.tar.gz"
+	if err := downloadTarball(url, origBin+".new"); err != nil {
+		t.Fatalf("downloadTarball: %v", err)
+	}
+	if err := os.Rename(origBin+".new", origBin); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	got, err := os.ReadFile(origBin)
+	if err != nil {
+		t.Fatalf("reading upgraded binary: %v", err)
+	}
+	if !strings.Contains(string(got), "fake") {
+		t.Errorf("upgraded binary content unexpected: %s", got)
+	}
+}
+
+// buildFakeTarball creates an in-memory .tar.gz with a single file named name
+// and the given content.
+func buildFakeTarball(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	hdr := &tar.Header{
+		Name:     name,
+		Mode:     0755,
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("tar WriteHeader: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("tar Write: %v", err)
+	}
+	tw.Close()
+	gw.Close()
+	return buf.Bytes()
+}

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -2,8 +2,8 @@ package upgrade
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -62,8 +62,7 @@ func TestFetchLatest_ParsesTagName(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Temporarily override releasesAPI by using a helper that accepts a URL.
-	tag, err := fetchLatestFromURL(srv.URL)
+	tag, err := FetchLatest(srv.URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -78,7 +77,7 @@ func TestFetchLatest_RateLimited(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchLatestFromURL(srv.URL)
+	_, err := FetchLatest(srv.URL)
 	if err == nil {
 		t.Fatal("expected error for rate-limited response")
 	}
@@ -87,38 +86,20 @@ func TestFetchLatest_RateLimited(t *testing.T) {
 	}
 }
 
-// fetchLatestFromURL is a testable variant of FetchLatest that targets an
-// arbitrary URL instead of the hardcoded GitHub API endpoint.
-func fetchLatestFromURL(url string) (string, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", err
+func TestFetchLatest_UnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := FetchLatest(srv.URL)
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
-		return "", newRateLimitError()
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should mention status code 500, got: %v", err)
 	}
-	if resp.StatusCode != http.StatusOK {
-		return "", newStatusError(resp.StatusCode)
-	}
-	var rel Release
-	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
-		return "", err
-	}
-	return rel.TagName, nil
 }
-
-func newRateLimitError() error {
-	return &upgradeError{"GitHub API rate limit exceeded — try again later"}
-}
-
-func newStatusError(code int) error {
-	return &upgradeError{msg: strings.Join([]string{"GitHub API returned unexpected status"}, " ")}
-}
-
-type upgradeError struct{ msg string }
-
-func (e *upgradeError) Error() string { return e.msg }
 
 // --- Unit tests: deteccion de Homebrew prefix ---
 
@@ -130,7 +111,7 @@ func TestIsHomebrew(t *testing.T) {
 		{"/opt/homebrew/bin/cvm", true},
 		{"/usr/local/Cellar/cvm/1.0.0/bin/cvm", true},
 		{"/usr/local/opt/cvm/bin/cvm", true},
-		{"/home/linuxbrew/.linuxbrew/bin/cvm", false}, // not an exact prefix match
+		{"/home/linuxbrew/.linuxbrew/bin/cvm", true}, // has prefix /home/linuxbrew/
 		{"/home/linuxbrew/cvm", true},
 		{"/home/user/.local/bin/cvm", false},
 		{"/usr/local/bin/cvm", false},


### PR DESCRIPTION
Closes #66

Plan de implementacion para #66: **Upgrade CVM al ultimo release estable**.

Archivo: `.portable/plans/66-upgrade-cvm-al-ultimo-release-estable.md`

Este PR es el inicio del trabajo sobre la spec — los PRs de implementacion vendran despues, referenciando este plan.

---

_PR generado por `/portable-plan`._
