### PR TITLE
Plan for #68: Agregar /portable-auto pipeline end-to-end

### DIFF
--- a/.portable/plans/68-agregar-portable-auto-pipeline-end-to-end-de-spec.md
+++ b/.portable/plans/68-agregar-portable-auto-pipeline-end-to-end-de-spec.md
@@ -1,0 +1,89 @@
+# Plan: Agregar /portable-auto: pipeline end-to-end de spec a PR validado
+
+Refs #68 · https://github.com/chichex/cvm/issues/68
+
+## Contexto
+
+`/portable-auto` es un nuevo skill del profile portable que orquesta el pipeline existente `/portable-spec` → `/portable-plan` → `/portable-code-loop` desde un único punto de entrada. Acepta como input un prompt libre, un issue normal, o un issue ya etiquetado con `entity:spec`. Detecta el tipo de input automáticamente, evalúa el "tamaño" del cambio en dos puntos del flow (post-spec y post-plan), emite advertencias bloqueantes cuando el cambio supera thresholds, y al final clasifica el resultado en categorías cualitativas. v1 es **Claude Code only** (asunción 26 del spec).
+
+## Objetivo
+
+Proveer un comando único que lleve a un usuario desde un prompt o issue hasta un PR validado, reusando los skills `/portable-*` ya desplegados, pausando solo en advertencias bloqueantes (cambio grande, input ambiguo, asunciones sin refinar) y emitiendo un veredicto cualitativo del fit al final.
+
+## Approach
+
+Implementar el skill como un único `SKILL.md` en `profiles/portable/claude/skills/portable-auto/`, escrito en la misma forma de prosa que el resto de skills `/portable-*` (sin frontmatter YAML, primera línea = description). El orquestador (Claude principal) parsea el input, compone llamadas a los skills hijos via Skill tool, y entre fases ejecuta dos chequeos heurísticos (post-spec y post-plan) que lee parseando los artefactos ya creados (issue y plan `.md`). Los thresholds viven inline en el SKILL.md como sección documentada, sin archivo de config externo. Para preservar la simetría del directorio paralelo `opencode/skills/`, se crea allí un stub que aborta de inmediato declarando "v1 Claude Code only".
+
+## Pasos
+
+- [ ] Crear `profiles/portable/claude/skills/portable-auto/SKILL.md` con la prosa completa del orquestador (sin frontmatter YAML, primera línea = descripción, siguiendo la convención del profile portable claude).
+- [ ] Implementar dentro del SKILL.md el parser de input (regex `^#?[0-9]+$` para número, `github.com/.+/issues/[0-9]+` para URL, cualquier otra cosa = prompt) y la pregunta de desambiguación multiple-choice cuando el input es ambiguo.
+- [ ] Implementar la rama por tipo de input: prompt → invocar `/portable-spec`; issue sin `entity:spec` → cargar body como historia y llamar `/portable-spec`; issue con `entity:spec` → saltar a `/portable-plan`.
+- [ ] Definir los thresholds default (`>10 asunciones`, `>8 pasos`, `>15 archivos`, `>15 asunciones sin refinar`) y documentarlos como sección `## Thresholds` en el SKILL.md.
+- [ ] Implementar los chequeos heurísticos post-spec y post-plan: parsear secciones del issue/plan (`## Asunciones validadas`, `## Pasos`, `## Archivos afectados`) y comparar contra los thresholds.
+- [ ] Implementar la advertencia bloqueante con tres respuestas (`continuar` / `abortar` / `ajustar`) y la rama "ajustar" que sugiere alternativas en prosa libre (dividir en specs más chicas, agregar más detalle, etc.).
+- [ ] Implementar el cómputo del veredicto final basado en señales cuantitativas: cantidad de iteraciones del loop, presencia de `code:failed` intermedio (timeline API), y si alguna fase superó threshold de tamaño.
+- [ ] Documentar en el SKILL.md las cuatro categorías de fit (`encajó limpio` / `encajó con fricción` / `encajó con riesgo residual` / `no encajó`) con sus criterios de clasificación.
+- [ ] Crear `profiles/portable/opencode/skills/portable-auto/SKILL.md` como stub con frontmatter YAML que aborta inmediatamente con mensaje "v1 Claude Code only — corre el skill desde Claude Code".
+- [ ] Actualizar `profiles/portable/CLAUDE.md` agregando una fila en la tabla de skills con la descripción de `/portable-auto`.
+- [ ] Probar manualmente el skill end-to-end con un caso simple durante el code-loop (prompt → spec → plan → loop) y verificar el formato del output final.
+
+## Archivos afectados
+
+- `profiles/portable/claude/skills/portable-auto/SKILL.md` — crear — skill principal con la lógica completa.
+- `profiles/portable/opencode/skills/portable-auto/SKILL.md` — crear — stub que aborta (preserva simetría del directorio).
+- `profiles/portable/CLAUDE.md` — modificar — agregar fila en la tabla de skills.
+
+## Riesgos
+
+- El skill compone llamadas a otros skills via Skill tool (`/portable-spec`, `/portable-plan`, `/portable-code-loop`). Si el runtime de Claude Code no permite Skills anidados o tiene restricciones desconocidas, hay que caer a fallback de prosa pidiendo al usuario invocar manualmente cada paso. Validar durante code-loop.
+- Los thresholds heurísticos pueden ser molestos si están mal calibrados; sin telemetría es difícil afinarlos en v1. Documentar valores explícitos para que el usuario los entienda al ver la advertencia.
+- El profile portable ya tiene versiones opencode reales de `/portable-code-loop`/`/portable-code-exec`/`/portable-code-validate` (delegan a `agents` en lugar de subagents). La asunción 26 del spec ("Claude Code only por subagents") es parcialmente incorrecta — OpenCode podría ser viable, pero v1 igual lo deja para después.
+- Parseo de secciones del issue/plan via regex sobre Markdown es frágil: si el formato del issue de spec o del `.md` del plan cambia (los skills `/portable-spec` y `/portable-plan` cambian de output), los chequeos pueden romper. Definir los markers explícitamente (`## Asunciones validadas`, `## Pasos`, `## Archivos afectados`).
+- "Encajó con riesgo residual" como categoría requiere que el skill recuerde si tiró advertencia de tamaño en alguna fase — implica state persistence dentro de la conversación del orquestador, no en disco.
+- Detección de `code:failed` intermedio depende de la API de timeline de GitHub (`gh api repos/<repo>/issues/<pr>/timeline`); si la respuesta cambia o es incompleta, el feedback puede clasificar mal.
+
+## Out of scope
+
+- Soporte funcional real de OpenCode (queda como stub que aborta hasta v2).
+- Flags adicionales: `--max`, `--auto`, `--no-confirm`, `--threshold` (todos fuera de v1).
+- Auto-tuning de thresholds basado en historial.
+- Cleanup automático de artefactos parciales (issue/PR) si el usuario aborta — el usuario los hereda.
+- Persistencia de estado en disco — todo vive en la conversación.
+- Tests automatizados del skill (sigue la convención del profile, los SKILL.md no tienen suite).
+- Telemetría / métricas de uso.
+- Nuevos labels propios — el skill se apoya en los que aplican los hijos (`entity:spec`, `entity:plan`, `code:exec`, `code:passed`, `code:failed`).
+
+## Asunciones tecnicas validadas
+
+1. La implementación es 100% prosa en Markdown dentro de un único `SKILL.md`, igual que el resto de skills del profile portable. No hay código Go ni binario nuevo.
+2. La composición de skills hijos se hace via Skill tool (invocando `/portable-spec`, `/portable-plan`, `/portable-code-loop` como skills anidados desde el orquestador).
+3. El parseo de input vive como pseudocódigo de prosa dentro del SKILL.md (regex / heurísticas en bash + `gh`), no en un módulo Go aparte.
+4. Detección de issue: regex `^#?[0-9]+$` o URL `github.com/.+/issues/[0-9]+`. Cualquier otra cosa = prompt libre.
+5. Para detectar si un issue tiene `entity:spec`: `gh issue view N --json labels --jq '.labels[].name' | grep -Fxq entity:spec`.
+6. Los thresholds default son: `>10 asunciones`, `>8 pasos`, `>15 archivos`, `>15 asunciones sin refinar`. Se documentan como sección `## Thresholds` en SKILL.md, sin archivo de config externo.
+7. Las "asunciones" se cuentan parseando el body del issue de spec (sección `## Asunciones validadas` → líneas `^[0-9]+\.`).
+8. Los "pasos" se cuentan parseando el `.md` del plan (sección `## Pasos` → líneas `^- \[ \]`).
+9. Los "archivos" se cuentan parseando el `.md` del plan (sección `## Archivos afectados` → líneas que arrancan con `` - ` ``).
+10. La advertencia de tamaño se evalúa en dos puntos fijos: post-`/portable-spec` (antes de `/portable-plan`) y post-`/portable-plan` (antes de `/portable-code-loop`).
+11. El feedback final cuantitativo se computa leyendo: cantidad de iteraciones del loop (history del PR + comments del validator), si hubo `code:failed` intermedio (event log de labels via `gh api .../timeline`), y si alguna fase tiró advertencia de tamaño (estado en conversación).
+12. Categorías de fit final: `encajó limpio` (≤1 iteración, sin code:failed, sin advertencia de tamaño), `encajó con fricción` (>1 iter o code:failed presente, pero terminó en PASS), `encajó con riesgo residual` (PASS pero alguna fase superó threshold), `no encajó` (loop agotó iteraciones sin PASS).
+13. v1 crea AMBOS `SKILL.md` (claude completo + opencode stub) para preservar la simetría del directorio del profile, pero el opencode aborta de entrada con mensaje "Claude Code only".
+14. `/portable-auto` NO toca el branch ni el working tree directamente — eso queda 100% delegado a `/portable-plan` y `/portable-code-loop`.
+15. La interacción con el usuario (multiple-choice, confirmaciones de "ajustar") es pseudocódigo de prosa, sin scripts bash interactivos.
+16. Los outputs intermedios (URL del issue de spec, URL del PR de plan) se muestran via texto del orquestador apenas los devuelve el skill hijo.
+17. La opción "ajustar" propone alternativas en prosa libre (no reglas formales) — el orquestador improvisa según contexto.
+18. El SKILL.md de claude NO usa frontmatter YAML (primera línea de prosa = description); el de opencode SÍ usa frontmatter YAML (convención observada en el profile portable).
+19. `/portable-auto` no instala nada — vive en `profiles/portable/claude/skills/portable-auto/SKILL.md` y se distribuye via `cvm install` con los demás (renderPortableCollection ya copia todo).
+20. La documentación en `profiles/portable/CLAUDE.md` (fuente del profile, no runtime) se actualiza con una fila más en la tabla de skills. NO se toca `~/.claude/CLAUDE.md`.
+21. No se agregan tests automatizados al repo. La verificación end-to-end es manual durante el code-loop.
+22. Si el runtime de Claude Code no soporta Skills anidados, el SKILL.md cae a fallback: prosa pidiendo al usuario que ejecute manualmente cada `/portable-*` y vuelva a `/portable-auto` con el output. (Asunción a verificar en code-loop.)
+23. El skill NO aplica labels propios — se apoya en los labels que aplican los skills hijos (`entity:spec`, `entity:plan`, `code:exec`, `code:passed`, `code:failed`).
+24. El skill NO escribe a auto-memory ni a archivos persistentes fuera de los que generan los skills hijos.
+25. Las llamadas a `gh` son siempre con `--json + --jq` para parseo robusto, nunca scraping de output texto.
+26. Si `/portable-code-loop` agota iteraciones, `/portable-auto` toma el último estado (label del PR + último comment del validator) como input para el feedback final, sin reintentar.
+27. Para detectar code:failed intermedio: `gh api repos/<repo>/issues/<pr>/timeline --paginate` y filtrar eventos `labeled` con `code:failed`. Asume que la timeline API expone history de labels.
+
+---
+
+_Plan generado por `/portable-plan` a partir de #68._

--- a/profiles/portable/claude/CLAUDE.md
+++ b/profiles/portable/claude/CLAUDE.md
@@ -12,6 +12,7 @@ Profile orientado a definir specs portables y reutilizables a partir de historia
 | `/portable-code-exec` | (Claude Code only) Una sola pasada de implementacion sobre un PR con label `entity:plan`. Wrapper thin sobre el subagent `portable-code-executor` (Sonnet). Aplica label `code:exec` al final. Sin validacion. |
 | `/portable-code-validate` | (Claude Code only) Una sola pasada de validacion sobre un PR con label `entity:plan`. Wrapper thin sobre el subagent `portable-code-validator` (Opus). Aplica label `code:passed` o `code:failed` y postea el feedback como comment del PR. Sirve para auditar PRs propios o ajenos sin tocar codigo. |
 | `/portable-recover` | Adopta issues y PRs preexistentes al workflow portable: detecta el tipo de entidad, diagnostica labels y artefactos, genera `.portable/plans/<N>-<slug>.md` si falta, commitea y pushea al branch del PR, aplica `entity:spec` o `entity:plan`, y sugiere el siguiente comando del workflow. |
+| `/portable-auto` | (Claude Code only) Pipeline end-to-end desde un prompt o issue hasta un PR validado: orquesta `/portable-spec` → `/portable-plan` → `/portable-code-loop` automaticamente. Detecta el tipo de input, evalua el tamano del cambio en dos puntos del flow contra thresholds heuristicos, emite advertencias bloqueantes, y al final clasifica el resultado en una de cuatro categorias de fit (`encajo limpio` / `encajo con friccion` / `encajo con riesgo residual` / `no encajo`). |
 
 ## Subagents (Claude Code only)
 

--- a/profiles/portable/claude/skills/portable-auto/SKILL.md
+++ b/profiles/portable/claude/skills/portable-auto/SKILL.md
@@ -1,0 +1,339 @@
+Orquestar el pipeline completo `/portable-spec` → `/portable-plan` → `/portable-code-loop` desde un unico punto de entrada. Acepta como input un prompt libre, un numero/URL de issue, o un issue ya etiquetado con `entity:spec`. Detecta el tipo de input automaticamente, evalua el "tamano" del cambio post-spec y post-plan contra thresholds heuristicos, emite advertencias bloqueantes cuando el cambio supera esos limites, y al final clasifica el resultado en una de cuatro categorias de fit. `$ARGUMENTS` es el input (prompt, numero de issue o URL). Si viene vacio se pide.
+
+Skill **exclusivo para Claude Code** (depende de los subagents `portable-code-executor` y `portable-code-validator`). El orquestador (Claude principal) maneja la composicion de skills via Skill tool; si el runtime no soporta Skills anidados, cae a fallback de prosa.
+
+## Thresholds
+
+| Metrica | Threshold (advertencia si supera) |
+|---------|-----------------------------------|
+| Asunciones validadas (post-spec) | > 10 |
+| Pasos del plan (post-plan) | > 8 |
+| Archivos afectados (post-plan) | > 15 |
+| Asunciones sin refinar (post-spec) | > 15 |
+
+Estos valores viven aqui y son legibles por el usuario cuando ve la advertencia. No hay archivo de config externo.
+
+## Pre-flight
+
+### 1. Validar repo GitHub
+```bash
+gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null
+```
+Si falla, abortar:
+```
+No hay un repo GitHub configurado en este directorio. /portable-auto necesita un repo GitHub para operar.
+
+Configura el remote (`gh repo create` o `gh repo set-default`) y volve a correr.
+```
+
+### 2. Validar working tree limpio
+```bash
+git status --porcelain
+```
+Si hay cambios sin commitear, abortar:
+```
+Working tree no esta limpio. /portable-auto delega a /portable-plan que crea branches; commiteá o stashé los cambios pendientes antes de correr.
+```
+
+### 3. Parsear `$ARGUMENTS` y detectar tipo de input
+
+Si `$ARGUMENTS` esta vacio, pedir al usuario:
+```
+Pasame el input: puede ser un prompt libre, un numero de issue (ej: `42` o `#42`) o una URL de issue (ej: https://github.com/owner/repo/issues/42).
+```
+Esperar respuesta. **No** continuar hasta tenerla.
+
+Tipo de input (evaluar en orden):
+1. **Numero de issue**: si matchea `^#?[0-9]+$` — extraer el numero. Guardar como `INPUT_ISSUE`.
+2. **URL de issue**: si matchea `github\.com/.+/issues/[0-9]+` — extraer el numero del path. Guardar como `INPUT_ISSUE`.
+3. **Prompt libre**: cualquier otra cosa. Guardar como `INPUT_PROMPT`.
+
+Si el input puede interpretarse de mas de una forma (ej: un numero que podria ser un issue o parte de un prompt), preguntar al usuario en formato multiple-choice antes de continuar:
+```
+Tu input puede interpretarse de mas de una forma:
+
+1) Como numero de issue (#<N>)
+2) Como prompt libre: "<input>"
+3) Otra interpretacion (especificame)
+
+Cual es?
+```
+Esperar respuesta. **No** continuar hasta tenerla.
+
+## Fase 1 — Clasificacion del issue (si aplica) o arranque desde prompt
+
+### Rama A: input es un issue (`INPUT_ISSUE` definido)
+
+Cargar el issue:
+```bash
+gh issue view "$INPUT_ISSUE" --json title,body,labels,state --jq '{title:.title, state:.state, labels:[.labels[].name]}'
+```
+
+Si el issue no existe o da error, abortar con el error de `gh`.
+Si `state == "CLOSED"`, avisar y pedir confirmacion:
+```
+El issue #<INPUT_ISSUE> esta cerrado. Continuar igual? (si/no)
+```
+Si dice no, abortar.
+
+**Detectar si tiene `entity:spec`:**
+```bash
+gh issue view "$INPUT_ISSUE" --json labels --jq '.labels[].name' | grep -Fxq "entity:spec"
+```
+- Si tiene `entity:spec`: saltar directamente a **Fase 3** (arrancar desde `/portable-plan`). Guardar `SPEC_ISSUE = INPUT_ISSUE`. Anotar `skipped_spec = true`.
+- Si NO tiene `entity:spec`: usar el body del issue como historia de usuario. Guardar `INPUT_PROMPT = body`. Continuar a **Fase 2** (arrancar desde `/portable-spec`). Anotar `skipped_spec = false`.
+
+### Rama B: input es prompt libre (`INPUT_PROMPT` definido)
+
+Continuar directamente a **Fase 2**. Anotar `skipped_spec = false`.
+
+## Fase 2 — Invocar `/portable-spec`
+
+Anunciar al usuario:
+```
+--- Fase 1/3: /portable-spec ---
+```
+
+**Invocar el skill `/portable-spec`** con `INPUT_PROMPT` como argumento.
+
+Si el runtime de Claude Code soporta Skills anidados: usar Skill tool con `/portable-spec`.
+**Fallback** (si Skills anidados no estan disponibles): pausar y pedirle al usuario:
+```
+Skills anidados no disponibles en este entorno. Por favor:
+1. Corre `/portable-spec <historia>` manualmente.
+2. Una vez creado el issue, volvé a /portable-auto con el numero de issue resultante.
+```
+Y abortar esta invocacion.
+
+Esperar el resultado de `/portable-spec`. Parsear el `## Result` del output:
+```bash
+# Extraer el numero de issue del URL
+SPEC_URL=$(echo "$spec_result" | grep -E '^- url:' | sed 's/^- url: //')
+SPEC_ISSUE=$(echo "$SPEC_URL" | grep -oE '[0-9]+$')
+ASSUMPTIONS_TOTAL=$(echo "$spec_result" | grep -E '^- assumptions_total:' | grep -oE '[0-9]+')
+ASSUMPTIONS_REFINED=$(echo "$spec_result" | grep -E '^- assumptions_refined:' | grep -oE '[0-9]+')
+```
+
+Guardar `skipped_spec = false`.
+
+Mostrar al usuario:
+```
+Spec creada: <SPEC_URL>
+Asunciones: <ASSUMPTIONS_TOTAL> totales, <ASSUMPTIONS_REFINED> refinadas.
+```
+
+### Chequeo heuristico post-spec
+
+Cargar el body del issue de spec para contar asunciones:
+```bash
+gh issue view "$SPEC_ISSUE" --json body --jq '.body'
+```
+
+Contar asunciones validadas (lineas `^[0-9]+\.` dentro de la seccion `## Asunciones validadas`):
+- Extraer el bloque entre `## Asunciones validadas` y el siguiente `##`.
+- Contar las lineas que arrancan con `<N>.` (numero seguido de punto).
+- Guardar como `COUNT_ASSUMPTIONS`.
+
+Contar asunciones sin refinar: `COUNT_UNREFINED = ASSUMPTIONS_TOTAL - ASSUMPTIONS_REFINED` (si los valores no estan disponibles, usar `COUNT_ASSUMPTIONS` como estimacion conservadora).
+
+**Evaluar thresholds:**
+- Si `COUNT_ASSUMPTIONS > 10` O `COUNT_UNREFINED > 15`: anotar `size_warning_spec = true` y ejecutar **Advertencia bloqueante** (ver mas abajo).
+- Si no supera ningun threshold: continuar a Fase 3.
+
+## Fase 3 — Invocar `/portable-plan`
+
+Anunciar al usuario:
+```
+--- Fase 2/3: /portable-plan ---
+```
+
+**Invocar el skill `/portable-plan`** con `SPEC_ISSUE` como argumento.
+
+Si el runtime no soporta Skills anidados: pausar y pedirle al usuario que corra `/portable-plan <SPEC_ISSUE>` manualmente y vuelva con el numero de PR resultante.
+
+Esperar el resultado de `/portable-plan`. Parsear el `## Result` del output:
+```bash
+PLAN_PR=$(echo "$plan_result" | grep -E '^- pr:' | grep -oE '[0-9]+')
+PLAN_URL=$(echo "$plan_result" | grep -E '^- url:' | sed 's/^- url: //')
+PLAN_FILE=$(echo "$plan_result" | grep -E '^- plan_file:' | sed 's/^- plan_file: //')
+```
+
+Mostrar al usuario:
+```
+Plan creado: <PLAN_URL>
+```
+
+### Chequeo heuristico post-plan
+
+Leer el archivo `.portable/plans/<N>-<slug>.md` del PR recien creado:
+```bash
+gh pr diff "$PLAN_PR" --name-only | grep '\.portable/plans/'
+# Leer el archivo via Read tool
+```
+
+Contar pasos (lineas `^- \[ \]` dentro de la seccion `## Pasos`):
+- Extraer el bloque entre `## Pasos` y el siguiente `##`.
+- Contar las lineas que arrancan con `- [ ]`.
+- Guardar como `COUNT_STEPS`.
+
+Contar archivos afectados (lineas que arrancan con `` - ` `` dentro de la seccion `## Archivos afectados`):
+- Extraer el bloque entre `## Archivos afectados` y el siguiente `##`.
+- Contar las lineas que arrancan con `` - ` ``.
+- Guardar como `COUNT_FILES`.
+
+**Evaluar thresholds:**
+- Si `COUNT_STEPS > 8` O `COUNT_FILES > 15`: anotar `size_warning_plan = true` y ejecutar **Advertencia bloqueante** (ver mas abajo).
+- Si no supera ningun threshold: continuar a Fase 4.
+
+## Advertencia bloqueante
+
+Cuando un threshold se supera, mostrar al usuario:
+
+```
+--- Advertencia de tamano ---
+
+El cambio supera los thresholds configurados:
+<listar las metricas que superaron, ej:>
+  - Asunciones: <COUNT_ASSUMPTIONS> (threshold: 10)
+  - Pasos: <COUNT_STEPS> (threshold: 8)
+
+Este tipo de cambio es grande para el pipeline automatico y puede generar friction o necesitar mas iteraciones.
+
+Como queres continuar?
+
+1) continuar — seguir con el pipeline igual
+2) abortar   — detener aqui; los artefactos ya creados quedan en GitHub para que los uses manualmente
+3) ajustar   — te sugiero alternativas para reducir el scope
+
+Cual elegis?
+```
+
+Esperar respuesta del usuario. **No** continuar hasta tenerla.
+
+- Si elige `1` (continuar): registrar la advertencia en estado de conversacion y continuar.
+- Si elige `2` (abortar): mostrar los URLs de los artefactos ya creados y abortar:
+  ```
+  Detenido. Artefactos creados hasta ahora:
+  <si existe SPEC_URL:>  - Spec: <SPEC_URL>
+  <si existe PLAN_URL:>  - Plan: <PLAN_URL>
+  Podes retomar manualmente usando /portable-plan o /portable-code-loop.
+  ```
+- Si elige `3` (ajustar): proponer alternativas en prosa libre segun contexto. Ejemplos tipicos:
+  - "Podes dividir la historia en dos specs: una para X y otra para Y."
+  - "Podes acotar el scope a solo la parte de Z y dejar el resto para un follow-up."
+  - "Podes refinar mas asunciones con /portable-spec antes de generar el plan."
+  Despues de sugerir, preguntar:
+  ```
+  Querés ajustar el scope y volver a correr, o preferís continuar igual?
+  1) Ajusto y vuelvo a correr
+  2) Continuar igual
+  ```
+  Si elige `1`: abortar con instrucciones de como retomar. Si elige `2`: continuar.
+
+## Fase 4 — Invocar `/portable-code-loop`
+
+Anunciar al usuario:
+```
+--- Fase 3/3: /portable-code-loop ---
+```
+
+**Invocar el skill `/portable-code-loop`** con `PLAN_PR` como argumento.
+
+Si el runtime no soporta Skills anidados: pausar y pedirle al usuario que corra `/portable-code-loop <PLAN_PR>` manualmente.
+
+Esperar el resultado de `/portable-code-loop`. Parsear el `## Result` del output:
+```bash
+LOOP_VERDICT=$(echo "$loop_result" | grep -E '^- verdict:' | sed 's/^- verdict: //')
+LOOP_ITERATIONS=$(echo "$loop_result" | grep -E '^- iterations_used:' | sed 's/^- iterations_used: //')
+# Forma: "N/MAX_ITER" — extraer N
+ITER_USED=$(echo "$LOOP_ITERATIONS" | cut -d'/' -f1)
+ITER_MAX=$(echo "$LOOP_ITERATIONS" | cut -d'/' -f2)
+```
+
+### Detectar si hubo `code:failed` intermedio
+
+```bash
+OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+gh api "repos/$OWNER_REPO/issues/$PLAN_PR/timeline" --paginate \
+  --jq '.[] | select(.event == "labeled" and .label.name == "code:failed") | .label.name' \
+  | grep -c "code:failed"
+```
+
+Si el count es `> 0`: anotar `had_code_failed = true`. Si es `0`: `had_code_failed = false`.
+
+## Fase 5 — Veredicto final de fit
+
+Calcular la categoria de fit basada en las senales acumuladas en la conversacion:
+
+| Categoria | Criterios |
+|-----------|-----------|
+| **encajo limpio** | `LOOP_VERDICT == PASS` Y `ITER_USED <= 1` Y `had_code_failed == false` Y `size_warning_spec == false` Y `size_warning_plan == false` |
+| **encajo con friccion** | `LOOP_VERDICT == PASS` Y (`ITER_USED > 1` O `had_code_failed == true`) Y `size_warning_spec == false` Y `size_warning_plan == false` |
+| **encajo con riesgo residual** | `LOOP_VERDICT == PASS` Y (`size_warning_spec == true` O `size_warning_plan == true`) |
+| **no encajo** | `LOOP_VERDICT != PASS` (loop agoto iteraciones sin PASS) |
+
+Nota: si aplican multiples categorias, priorizar la mas "grave" en orden: `no encajo` > `encajo con riesgo residual` > `encajo con friccion` > `encajo limpio`.
+
+Mostrar el veredicto final:
+
+```
+## Resultado /portable-auto
+
+- spec: <SPEC_URL o "skipped (input era entity:spec)">
+- plan: <PLAN_URL>
+- pr: <PR_URL del loop>
+- iteraciones: <ITER_USED>/<ITER_MAX>
+- verdict loop: <PASS|FAIL>
+- fit: <categoria>
+
+### Detalle del fit
+
+<Categoria elegida con explicacion concisa de por que:>
+
+**encajo limpio** — El pipeline corrio sin friction: una iteracion, sin fallos intermedios, dentro de los thresholds de tamano. El PR esta listo para review.
+
+— o —
+
+**encajo con friccion** — El pipeline termino en PASS pero requirio <ITER_USED> iteraciones <y/o hubo code:failed intermedios>. El resultado es correcto pero el cambio genero trabajo extra en el loop.
+
+— o —
+
+**encajo con riesgo residual** — El pipeline termino en PASS pero el cambio supero thresholds de tamano (<listar cuales>). El codigo esta validado pero el scope amplio implica mayor superficie de error no cubierta por el loop automatico. Se recomienda revision humana cuidadosa.
+
+— o —
+
+**no encajo** — El loop agoto sus iteraciones sin alcanzar PASS. El PR quedo en su ultimo estado. Revisa el feedback del ultimo validate y decide si retomar manualmente o cerrar.
+
+---
+<si PASS:>
+PR listo para review/merge: <PR_URL>
+<si FAIL:>
+Estado final del PR: <PR_URL> — label: code:failed
+```
+
+## MUST DO
+
+- Validar `gh repo view` y working tree limpio ANTES de procesar el input.
+- Detectar el tipo de input en orden: numero > URL > prompt libre.
+- Pedir desambiguacion en multiple-choice cuando el input es ambiguo.
+- Verificar label `entity:spec` en el issue antes de decidir si saltar `/portable-spec`.
+- Ejecutar chequeo heuristico post-spec (antes de `/portable-plan`) y post-plan (antes de `/portable-code-loop`).
+- Mostrar advertencia bloqueante con opciones `continuar` / `abortar` / `ajustar` cuando se supera un threshold.
+- Anotar en estado de conversacion si se disparo advertencia de tamano en alguna fase (`size_warning_spec`, `size_warning_plan`).
+- Detectar `code:failed` intermedio via timeline API de GitHub.
+- Calcular y mostrar el veredicto final de fit con la categoria correcta.
+- Usar `--json + --jq` en todas las llamadas a `gh` (nunca scraping de texto).
+- Pasar contenido de usuario via archivo temporal (Write tool) en lugar de interpolacion en shell.
+
+## MUST NOT DO
+
+- No invocar `/portable-code-loop` sin haber completado `/portable-plan` primero.
+- No saltear el chequeo heuristico de tamano aunque parezca obvio que el cambio es chico.
+- No persistir estado en disco — todo vive en la conversacion.
+- No aplicar labels propios — los labels los aplican los skills hijos.
+- No tocar `~/.claude/CLAUDE.md` en runtime.
+- No agregar lo que no se pidio (flags extra, labels extras, etc.).
+- No continuar despues de advertencia bloqueante sin esperar respuesta del usuario.
+- No persistir nada en auto-memory.
+- No delegar a subagent directo — la orquestacion vive en el orquestador principal.
+- No avanzar de fase sin tener el resultado parseado de la fase anterior.

--- a/profiles/portable/opencode/skills/portable-auto/SKILL.md
+++ b/profiles/portable/opencode/skills/portable-auto/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: portable-auto
+description: Pipeline end-to-end spec → plan → code-loop (v1 Claude Code only)
+---
+
+v1 de este skill es **Claude Code only** — no esta disponible en OpenCode.
+
+Para correr el pipeline completo `/portable-spec` → `/portable-plan` → `/portable-code-loop`, usa Claude Code y ejecuta `/portable-auto`.


### PR DESCRIPTION
Closes #68

Plan de implementacion para #68: **Agregar /portable-auto: pipeline end-to-end de spec a PR validado**.

Archivo: `.portable/plans/68-agregar-portable-auto-pipeline-end-to-end-de-spec.md`

Este PR es el inicio del trabajo sobre la spec — los PRs de implementacion vendran despues, referenciando este plan.

---

_PR generado por `/portable-plan`._
