### PR TITLE
feat: add uninstall.sh + verify-uninstall.sh

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+# uninstall.sh — cleanly remove cvm while keeping the ACTIVE profile's config.
+#
+# cvm activates a profile by symlinking the profile's files (which live in the
+# profile's source repo, e.g. ~/.cvm/profiles/<name> or a path-registered dir)
+# into each harness target dir (~/.claude, ~/.codex, ~/.config/opencode). If we
+# deleted cvm's state first, those symlinks would dangle and you'd lose the
+# config you're actually using.
+#
+# So the order here is:
+#   1. MATERIALIZE — replace every cvm-managed symlink in the target dirs with a
+#      real, dereferenced copy of its current contents. This freezes the active
+#      profile's config in place as plain files, decoupled from cvm and the repo.
+#   2. BACKUP (default on) — tar up cvm's own artifacts (state.json, vanilla
+#      stash, cloned profiles) so nothing is irreversibly lost.
+#   3. REMOVE — delete ONLY cvm's artifacts inside ~/.cvm (never the whole dir,
+#      which may be shared with other tooling) and uninstall the cvm binary.
+#   4. VERIFY — run verify-uninstall.sh to confirm a clean end state.
+#
+# This script does NOT depend on the cvm binary (works even if it's broken).
+#
+# Usage:
+#   ./uninstall.sh [--yes] [--no-backup] [--dry-run]
+#     --yes        skip the confirmation prompt
+#     --no-backup  don't tar cvm's artifacts before deleting them
+#     --dry-run    print what would happen, change nothing
+set -eu
+
+CVM_HOME="${HOME}/.cvm"
+STATE_FILE="${CVM_HOME}/state.json"
+VANILLA_DIR="${CVM_HOME}/vanilla"
+PROFILES_DIR="${CVM_HOME}/profiles"
+INSTALL_BIN="${HOME}/.local/bin/cvm"   # install.sh location
+
+CLAUDE_DIR="${HOME}/.claude"
+CODEX_DIR="${CODEX_HOME:-${HOME}/.codex}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-${HOME}/.config/opencode}"
+
+# Managed items per harness (mirror the managed*DirItems slices in Go).
+CLAUDE_ITEMS="CLAUDE.md settings.json settings.local.json keybindings.json statusline-command.sh commands skills agents hooks rules output-styles teams"
+CODEX_ITEMS="AGENTS.md"
+OPENCODE_ITEMS="AGENTS.md opencode.json skills agents commands plugin plugins"
+
+YES=0; BACKUP=1; DRY=0
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) YES=1 ;;
+    --no-backup) BACKUP=0 ;;
+    --dry-run|-n) DRY=1 ;;
+    -h|--help) sed -n '2,33p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ -t 1 ]; then
+  GREEN=$(printf '\033[32m'); RED=$(printf '\033[31m'); YEL=$(printf '\033[33m'); BLU=$(printf '\033[34m'); RST=$(printf '\033[0m')
+else
+  GREEN=; RED=; YEL=; BLU=; RST=
+fi
+info() { printf '%s::%s %s\n' "$BLU" "$RST" "$1"; }
+ok()   { printf '%s ok%s %s\n' "$GREEN" "$RST" "$1"; }
+warn() { printf '%swarn%s %s\n' "$YEL" "$RST" "$1"; }
+act()  { if [ "$DRY" -eq 1 ]; then printf '%s[dry-run]%s would %s\n' "$YEL" "$RST" "$1"; else printf '       %s\n' "$1"; fi; }
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+# --- Report current state (best effort, never fatal) ---
+info "cvm uninstall"
+if [ -f "$STATE_FILE" ]; then
+  # The harnesses block maps harness -> active profile; show those lines only.
+  actives=$(grep -E '"(claude|opencode|codex)": *"' "$STATE_FILE" 2>/dev/null | sed -E 's/.*"([a-z]+)": *"([^"]*)".*/\1=\2/' | tr '\n' ' ' || true)
+  [ -n "$actives" ] && info "active profile per harness: $actives"
+fi
+HAVE_BREW=0
+if command -v brew >/dev/null 2>&1 && brew list cvm >/dev/null 2>&1; then HAVE_BREW=1; fi
+if [ ! -e "$STATE_FILE" ] && [ ! -e "$VANILLA_DIR" ] && [ ! -e "$PROFILES_DIR" ] \
+   && [ ! -e "$INSTALL_BIN" ] && [ "$HAVE_BREW" -eq 0 ] && ! command -v cvm >/dev/null 2>&1; then
+  warn "nothing to uninstall — no cvm artifacts or binary found."
+fi
+
+# --- Confirmation ---
+if [ "$DRY" -eq 0 ] && [ "$YES" -eq 0 ]; then
+  printf '\nThis will materialize your ACTIVE profile config as real files, then remove\n'
+  printf "cvm's state (state.json, vanilla, profiles) and the cvm binary.\n"
+  printf 'Your repos and any non-cvm data under ~/.cvm are left untouched.\n'
+  [ "$BACKUP" -eq 1 ] && printf "A backup tarball of cvm's artifacts will be created first.\n"
+  printf 'Continue? [y/N] '
+  read -r reply || reply=""
+  case "$reply" in y|Y|yes|YES) ;; *) echo "aborted."; exit 1 ;; esac
+fi
+
+# --- Step 1: materialize cvm-managed symlinks into real files ---
+# At a managed-item path, cvm is the only thing that creates symlinks (real files
+# there are yours/vanilla and are left untouched). So: any symlink at such a path
+# is cvm's — dereference it into a real copy in place. Dangling ones (profile
+# source gone) are removed with a warning.
+materialize() {
+  path=$1; label=$2
+  [ -L "$path" ] || return 0
+  target=$(readlink "$path" 2>/dev/null || echo "?")
+  if [ ! -e "$path" ]; then
+    warn "$label: dangling symlink (target missing) $path -> $target"
+    act "remove dangling symlink $path"
+    [ "$DRY" -eq 1 ] || rm -f "$path"
+    return 0
+  fi
+  act "materialize $path (was -> $target)"
+  if [ "$DRY" -eq 0 ]; then
+    tmp="${path}.cvm-uninstall.$$"
+    rm -rf "$tmp"
+    cp -RL "$path" "$tmp"   # -L dereferences the symlink and any nested links
+    rm -f "$path"
+    mv "$tmp" "$path"
+  fi
+}
+
+materialize_dir() {
+  dir=$1; items=$2; label=$3
+  [ -d "$dir" ] || return 0
+  for item in $items; do
+    materialize "$dir/$item" "$label"
+  done
+}
+
+info "materializing active-profile config (symlinks -> real files)"
+materialize_dir "$CLAUDE_DIR" "$CLAUDE_ITEMS" "claude"
+materialize_dir "$CODEX_DIR" "$CODEX_ITEMS" "codex"
+materialize_dir "$OPENCODE_DIR" "$OPENCODE_ITEMS" "opencode"
+ok "materialization done"
+
+# --- Step 2: backup cvm's own artifacts ---
+if [ "$BACKUP" -eq 1 ]; then
+  set --
+  [ -e "$STATE_FILE" ]   && set -- "$@" state.json
+  [ -e "$VANILLA_DIR" ]  && set -- "$@" vanilla
+  [ -e "$PROFILES_DIR" ] && set -- "$@" profiles
+  if [ "$#" -gt 0 ]; then
+    ts=$(date +%Y%m%d-%H%M%S 2>/dev/null || echo backup)
+    backup="${HOME}/cvm-backup-${ts}.tar.gz"
+    info "backing up cvm artifacts ($*) to $backup"
+    act "create $backup"
+    if [ "$DRY" -eq 0 ]; then
+      tar -czf "$backup" -C "$CVM_HOME" "$@" && ok "backup written: $backup"
+    fi
+  fi
+fi
+
+# --- Step 3: remove cvm artifacts (surgical — ~/.cvm may be shared) ---
+info "removing cvm artifacts under ~/.cvm"
+for p in "$STATE_FILE" "$VANILLA_DIR" "$PROFILES_DIR"; do
+  if [ -e "$p" ]; then
+    act "rm -rf $p"
+    [ "$DRY" -eq 1 ] || rm -rf "$p"
+  fi
+done
+# If ~/.cvm now holds nothing but cvm ever created, and it's empty, drop it too.
+if [ -d "$CVM_HOME" ] && [ -z "$(ls -A "$CVM_HOME" 2>/dev/null)" ]; then
+  act "rmdir empty $CVM_HOME"
+  [ "$DRY" -eq 1 ] || rmdir "$CVM_HOME"
+fi
+
+# --- Step 3b: remove the binary (detect install method) ---
+info "removing cvm binary"
+if [ "$HAVE_BREW" -eq 1 ]; then
+  act "brew uninstall cvm"
+  [ "$DRY" -eq 1 ] || brew uninstall cvm || warn "brew uninstall cvm failed"
+fi
+if [ -e "$INSTALL_BIN" ]; then
+  act "rm -f $INSTALL_BIN"
+  [ "$DRY" -eq 1 ] || rm -f "$INSTALL_BIN"
+fi
+# go install location, if any.
+if command -v go >/dev/null 2>&1; then
+  gobin="$(go env GOPATH 2>/dev/null)/bin/cvm"
+  if [ -e "$gobin" ]; then
+    act "rm -f $gobin"
+    [ "$DRY" -eq 1 ] || rm -f "$gobin"
+  fi
+fi
+
+if [ "$DRY" -eq 0 ] && command -v cvm >/dev/null 2>&1; then
+  warn "a 'cvm' is still on PATH at $(command -v cvm) — installed by an unrecognized method; remove it manually."
+fi
+
+if [ "$DRY" -eq 1 ]; then
+  echo; warn "dry-run complete — nothing was changed."
+  exit 0
+fi
+
+# --- Step 4: verify ---
+echo
+info "verifying clean uninstall"
+if [ -f "$SCRIPT_DIR/verify-uninstall.sh" ]; then
+  sh "$SCRIPT_DIR/verify-uninstall.sh"
+else
+  warn "verify-uninstall.sh not found next to this script; skipping validation."
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -11,19 +11,25 @@
 #   1. MATERIALIZE — replace every cvm-managed symlink in the target dirs with a
 #      real, dereferenced copy of its current contents. This freezes the active
 #      profile's config in place as plain files, decoupled from cvm and the repo.
-#   2. BACKUP (default on) — tar up cvm's own artifacts (state.json, vanilla
-#      stash, cloned profiles) so nothing is irreversibly lost.
-#   3. REMOVE — delete ONLY cvm's artifacts inside ~/.cvm (never the whole dir,
+#   2. ORIGINALS — cvm stashed your pre-cvm config aside ("vanilla") when you
+#      first activated a profile, so it is the only copy. The active profile is
+#      kept regardless; we ASK whether to also keep a copy of those originals
+#      (default yes) and, if so, save them to ~/cvm-vanilla-<ts>/.
+#   3. BACKUP (default on) — tar up cvm's recovery data (state.json + cloned
+#      profiles) so nothing of cvm's own is irreversibly lost.
+#   4. REMOVE — delete ONLY cvm's artifacts inside ~/.cvm (never the whole dir,
 #      which may be shared with other tooling) and uninstall the cvm binary.
-#   4. VERIFY — run verify-uninstall.sh to confirm a clean end state.
+#   5. VERIFY — run verify-uninstall.sh to confirm a clean end state.
 #
 # This script does NOT depend on the cvm binary (works even if it's broken).
 #
 # Usage:
-#   ./uninstall.sh [--yes] [--no-backup] [--dry-run]
-#     --yes        skip the confirmation prompt
-#     --no-backup  don't tar cvm's artifacts before deleting them
-#     --dry-run    print what would happen, change nothing
+#   ./uninstall.sh [--yes] [--keep-originals|--discard-originals] [--no-backup] [--dry-run]
+#     --yes                skip the confirmation prompt (keeps originals unless --discard-originals)
+#     --keep-originals     keep your pre-cvm config at ~/cvm-vanilla-<ts>/ (no prompt)
+#     --discard-originals  drop your pre-cvm config (no prompt)
+#     --no-backup          don't tar cvm's profiles+state before deleting them
+#     --dry-run            print what would happen, change nothing
 set -eu
 
 CVM_HOME="${HOME}/.cvm"
@@ -41,10 +47,12 @@ CLAUDE_ITEMS="CLAUDE.md settings.json settings.local.json keybindings.json statu
 CODEX_ITEMS="AGENTS.md"
 OPENCODE_ITEMS="AGENTS.md opencode.json skills agents commands plugin plugins"
 
-YES=0; BACKUP=1; DRY=0
+YES=0; BACKUP=1; DRY=0; KEEP_ORIG=ask   # KEEP_ORIG: ask | yes | no
 for arg in "$@"; do
   case "$arg" in
     --yes|-y) YES=1 ;;
+    --keep-originals) KEEP_ORIG=yes ;;
+    --discard-originals) KEEP_ORIG=no ;;
     --no-backup) BACKUP=0 ;;
     --dry-run|-n) DRY=1 ;;
     -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
@@ -107,17 +115,35 @@ fi
 # --- Confirmation ---
 if [ "$DRY" -eq 0 ] && [ "$YES" -eq 0 ]; then
   printf '\nThis will materialize your ACTIVE profile config as real files, then remove\n'
-  printf "cvm's state (state.json, profiles, and the vanilla stash of your ORIGINAL\n"
-  printf 'pre-cvm config) and the cvm binary.\n'
+  printf "cvm's state (state.json, profiles) and the cvm binary.\n"
   printf 'Your repos and any non-cvm data under ~/.cvm are left untouched.\n'
   if [ "$BACKUP" -eq 1 ]; then
-    printf "A backup tarball of cvm's artifacts (incl. the vanilla originals) is created first.\n"
+    printf "A backup tarball of cvm's profiles + state is created first.\n"
   else
-    printf '%s--no-backup is set; the vanilla originals will be kept at ~/cvm-vanilla-<ts>/ instead.%s\n' "$YEL" "$RST"
+    printf '%s--no-backup is set; cvm profiles + state are deleted without a tarball.%s\n' "$YEL" "$RST"
   fi
   printf 'Continue? [y/N] '
   read -r reply || reply=""
   case "$reply" in y|Y|yes|YES) ;; *) echo "aborted."; exit 1 ;; esac
+fi
+
+# --- Decide what to do with your ORIGINAL pre-cvm config (the vanilla stash) ---
+# cvm MOVED these files aside when you first activated a profile, so they are the
+# only copy. The active profile is materialized regardless; this is purely about
+# whether to also keep a copy of what you had before cvm.
+VANILLA_NONEMPTY=0
+[ -d "$VANILLA_DIR" ] && [ -n "$(ls -A "$VANILLA_DIR" 2>/dev/null)" ] && VANILLA_NONEMPTY=1
+if [ "$VANILLA_NONEMPTY" -eq 1 ] && [ "$KEEP_ORIG" = ask ]; then
+  if [ "$DRY" -eq 0 ] && [ "$YES" -eq 0 ]; then
+    printf '\ncvm has your ORIGINAL pre-cvm config stashed (the files you had before cvm\n'
+    printf 'took over). The active profile is kept either way. Keep a copy of these\n'
+    printf 'originals at ~/cvm-vanilla-<ts>/? [Y/n] '
+    read -r r || r=""
+    case "$r" in n|N|no|NO) KEEP_ORIG=no ;; *) KEEP_ORIG=yes ;; esac
+  else
+    KEEP_ORIG=yes   # safe default when non-interactive (--yes / --dry-run)
+    [ "$DRY" -eq 1 ] && info "would ask whether to keep your pre-cvm originals (assuming keep)"
+  fi
 fi
 
 # --- Step 1: materialize cvm-managed symlinks into real files ---
@@ -165,21 +191,36 @@ materialize_dir "$CODEX_DIR" "$CODEX_ITEMS" "codex"
 materialize_dir "$OPENCODE_DIR" "$OPENCODE_ITEMS" "opencode"
 ok "materialization done"
 
-# --- Step 2: backup cvm's own artifacts ---
+# --- Step 2: keep a copy of your originals, if you asked to ---
+if [ "$VANILLA_NONEMPTY" -eq 1 ] && [ "$KEEP_ORIG" = yes ]; then
+  ts=$(date +%Y%m%d-%H%M%S 2>/dev/null || echo backup)
+  keep="${HOME}/cvm-vanilla-${ts}"
+  info "keeping a copy of your original pre-cvm config at $keep"
+  act "cp -R $VANILLA_DIR -> $keep"
+  if [ "$DRY" -eq 0 ]; then
+    # Guard the copy: this is the only copy of your originals, so a failure must
+    # abort before the removal below rather than silently losing them.
+    cp -R "$VANILLA_DIR" "$keep" \
+      || { echo "failed to copy originals to $keep — aborting before any deletion" >&2; exit 1; }
+    ok "originals kept: $keep"
+  fi
+elif [ "$VANILLA_NONEMPTY" -eq 1 ]; then
+  warn "discarding your original pre-cvm config (vanilla stash) as requested"
+fi
+
+# --- Step 3: backup cvm's recovery data (cloned profiles + state) ---
 if [ "$BACKUP" -eq 1 ]; then
   set --
   [ -e "$STATE_FILE" ]   && set -- "$@" state.json
-  [ -e "$VANILLA_DIR" ]  && set -- "$@" vanilla
   [ -e "$PROFILES_DIR" ] && set -- "$@" profiles
   if [ "$#" -gt 0 ]; then
     ts=$(date +%Y%m%d-%H%M%S 2>/dev/null || echo backup)
     backup="${HOME}/cvm-backup-${ts}.tar.gz"
-    info "backing up cvm artifacts ($*) to $backup"
+    info "backing up cvm recovery data ($*) to $backup"
     act "create $backup"
     if [ "$DRY" -eq 0 ]; then
-      # A failed backup MUST abort before we delete anything — otherwise a tar
-      # failure (full disk, unwritable/quota'd $HOME) would drop us into the rm
-      # below with no backup, destroying the only copy of the vanilla originals.
+      # A failed backup MUST abort before we delete anything, rather than dropping
+      # into the rm below with no backup at all.
       tar -czf "$backup" -C "$CVM_HOME" "$@" \
         || { echo "backup FAILED ($backup) — aborting before any deletion" >&2; exit 1; }
       tar -tzf "$backup" >/dev/null 2>&1 \
@@ -189,17 +230,7 @@ if [ "$BACKUP" -eq 1 ]; then
   fi
 fi
 
-# Even with --no-backup, never silently destroy the vanilla stash: cvm MOVED the
-# user's pre-cvm originals there (os.Rename), so it is their only copy. Keep it.
-if [ "$BACKUP" -eq 0 ] && [ -d "$VANILLA_DIR" ] && [ -n "$(ls -A "$VANILLA_DIR" 2>/dev/null)" ]; then
-  ts=$(date +%Y%m%d-%H%M%S 2>/dev/null || echo backup)
-  keep="${HOME}/cvm-vanilla-${ts}"
-  warn "vanilla/ holds your original pre-cvm config; preserving it at $keep despite --no-backup"
-  act "cp -R $VANILLA_DIR -> $keep"
-  [ "$DRY" -eq 1 ] || cp -R "$VANILLA_DIR" "$keep"
-fi
-
-# --- Step 3: remove cvm artifacts (surgical — ~/.cvm may be shared) ---
+# --- Step 4: remove cvm artifacts (surgical — ~/.cvm may be shared) ---
 info "removing cvm artifacts under ~/.cvm"
 for p in "$STATE_FILE" "$VANILLA_DIR" "$PROFILES_DIR"; do
   if [ -e "$p" ]; then
@@ -213,7 +244,7 @@ if [ -d "$CVM_HOME" ] && [ -z "$(ls -A "$CVM_HOME" 2>/dev/null)" ]; then
   [ "$DRY" -eq 1 ] || rmdir "$CVM_HOME"
 fi
 
-# --- Step 3b: remove the binary (detect install method) ---
+# --- Step 4b: remove the binary (detect install method) ---
 info "removing cvm binary"
 if [ "$HAVE_BREW" -eq 1 ]; then
   act "brew uninstall cvm"
@@ -252,7 +283,7 @@ if [ "$DRY" -eq 1 ]; then
   exit 0
 fi
 
-# --- Step 4: verify ---
+# --- Step 5: verify ---
 echo
 info "verifying clean uninstall"
 if [ -f "$SCRIPT_DIR/verify-uninstall.sh" ]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -47,7 +47,7 @@ for arg in "$@"; do
     --yes|-y) YES=1 ;;
     --no-backup) BACKUP=0 ;;
     --dry-run|-n) DRY=1 ;;
-    -h|--help) sed -n '2,33p' "$0"; exit 0 ;;
+    -h|--help) awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
     *) echo "unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
@@ -64,11 +64,37 @@ act()  { if [ "$DRY" -eq 1 ]; then printf '%s[dry-run]%s would %s\n' "$YEL" "$RS
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
+# Crash-safety: materialize() copies a symlink's contents to "<path>.cvm-uninstall.<pid>",
+# removes the symlink, then renames the copy into place. If we die in that window
+# the real data lives only in the temp; recover it. If the original is still there
+# (copy aborted) the temp is junk. Runs on every exit; a clean run leaves no temps.
+cleanup_temps() {
+  for d in "$CLAUDE_DIR" "$CODEX_DIR" "$OPENCODE_DIR"; do
+    [ -d "$d" ] || continue
+    for t in "$d"/*.cvm-uninstall."$$"; do
+      [ -e "$t" ] || continue
+      final="${t%.cvm-uninstall.$$}"
+      if [ -e "$final" ] || [ -L "$final" ]; then
+        rm -rf "$t"            # original intact, or swap already done — temp is junk
+      else
+        mv "$t" "$final"       # symlink gone but copy not yet in place — recover it
+      fi
+    done
+  done
+}
+trap cleanup_temps EXIT
+
 # --- Report current state (best effort, never fatal) ---
 info "cvm uninstall"
 if [ -f "$STATE_FILE" ]; then
-  # The harnesses block maps harness -> active profile; show those lines only.
-  actives=$(grep -E '"(claude|opencode|codex)": *"' "$STATE_FILE" 2>/dev/null | sed -E 's/.*"([a-z]+)": *"([^"]*)".*/\1=\2/' | tr '\n' ' ' || true)
+  # The global.harnesses block maps harness -> active profile; read only it so a
+  # profile literally named "claude"/"opencode" elsewhere can't skew the banner.
+  actives=$(awk '
+    /"harnesses"[[:space:]]*:/ {inh=1; next}
+    inh && /}/ {inh=0}
+    inh && match($0, /"[a-z]+"[[:space:]]*:[[:space:]]*"[^"]*"/) {
+      s=substr($0, RSTART, RLENGTH); gsub(/[" ]/, "", s); print s
+    }' "$STATE_FILE" 2>/dev/null | tr '\n' ' ' || true)
   [ -n "$actives" ] && info "active profile per harness: $actives"
 fi
 HAVE_BREW=0
@@ -81,9 +107,14 @@ fi
 # --- Confirmation ---
 if [ "$DRY" -eq 0 ] && [ "$YES" -eq 0 ]; then
   printf '\nThis will materialize your ACTIVE profile config as real files, then remove\n'
-  printf "cvm's state (state.json, vanilla, profiles) and the cvm binary.\n"
+  printf "cvm's state (state.json, profiles, and the vanilla stash of your ORIGINAL\n"
+  printf 'pre-cvm config) and the cvm binary.\n'
   printf 'Your repos and any non-cvm data under ~/.cvm are left untouched.\n'
-  [ "$BACKUP" -eq 1 ] && printf "A backup tarball of cvm's artifacts will be created first.\n"
+  if [ "$BACKUP" -eq 1 ]; then
+    printf "A backup tarball of cvm's artifacts (incl. the vanilla originals) is created first.\n"
+  else
+    printf '%s--no-backup is set; the vanilla originals will be kept at ~/cvm-vanilla-<ts>/ instead.%s\n' "$YEL" "$RST"
+  fi
   printf 'Continue? [y/N] '
   read -r reply || reply=""
   case "$reply" in y|Y|yes|YES) ;; *) echo "aborted."; exit 1 ;; esac
@@ -108,7 +139,13 @@ materialize() {
   if [ "$DRY" -eq 0 ]; then
     tmp="${path}.cvm-uninstall.$$"
     rm -rf "$tmp"
-    cp -RL "$path" "$tmp"   # -L dereferences the symlink and any nested links
+    # -L dereferences the symlink and any nested links. A broken nested link makes
+    # cp fail for this item only — keep the symlink, skip it, don't abort the run.
+    if ! cp -RL "$path" "$tmp" 2>/dev/null; then
+      rm -rf "$tmp"
+      warn "$label: could not fully materialize $path (broken nested symlink?); left as-is"
+      return 0
+    fi
     rm -f "$path"
     mv "$tmp" "$path"
   fi
@@ -140,9 +177,26 @@ if [ "$BACKUP" -eq 1 ]; then
     info "backing up cvm artifacts ($*) to $backup"
     act "create $backup"
     if [ "$DRY" -eq 0 ]; then
-      tar -czf "$backup" -C "$CVM_HOME" "$@" && ok "backup written: $backup"
+      # A failed backup MUST abort before we delete anything — otherwise a tar
+      # failure (full disk, unwritable/quota'd $HOME) would drop us into the rm
+      # below with no backup, destroying the only copy of the vanilla originals.
+      tar -czf "$backup" -C "$CVM_HOME" "$@" \
+        || { echo "backup FAILED ($backup) — aborting before any deletion" >&2; exit 1; }
+      tar -tzf "$backup" >/dev/null 2>&1 \
+        || { echo "backup unreadable ($backup) — aborting before any deletion" >&2; exit 1; }
+      ok "backup written: $backup"
     fi
   fi
+fi
+
+# Even with --no-backup, never silently destroy the vanilla stash: cvm MOVED the
+# user's pre-cvm originals there (os.Rename), so it is their only copy. Keep it.
+if [ "$BACKUP" -eq 0 ] && [ -d "$VANILLA_DIR" ] && [ -n "$(ls -A "$VANILLA_DIR" 2>/dev/null)" ]; then
+  ts=$(date +%Y%m%d-%H%M%S 2>/dev/null || echo backup)
+  keep="${HOME}/cvm-vanilla-${ts}"
+  warn "vanilla/ holds your original pre-cvm config; preserving it at $keep despite --no-backup"
+  act "cp -R $VANILLA_DIR -> $keep"
+  [ "$DRY" -eq 1 ] || cp -R "$VANILLA_DIR" "$keep"
 fi
 
 # --- Step 3: remove cvm artifacts (surgical — ~/.cvm may be shared) ---
@@ -169,13 +223,24 @@ if [ -e "$INSTALL_BIN" ]; then
   act "rm -f $INSTALL_BIN"
   [ "$DRY" -eq 1 ] || rm -f "$INSTALL_BIN"
 fi
-# go install location, if any.
-if command -v go >/dev/null 2>&1; then
-  gobin="$(go env GOPATH 2>/dev/null)/bin/cvm"
-  if [ -e "$gobin" ]; then
-    act "rm -f $gobin"
-    [ "$DRY" -eq 1 ] || rm -f "$gobin"
-  fi
+# go install location, if any. Guard an empty GOPATH so we never form "/bin/cvm";
+# fall back to Go's default ($HOME/go) so a go-installed binary is caught even
+# when `go` itself isn't on PATH.
+gp="$(go env GOPATH 2>/dev/null || true)"
+[ -n "$gp" ] || gp="${HOME}/go"
+if [ -e "$gp/bin/cvm" ]; then
+  act "rm -f $gp/bin/cvm"
+  [ "$DRY" -eq 1 ] || rm -f "$gp/bin/cvm"
+fi
+
+# If a Homebrew-prefix binary exists but brew wasn't resolvable, we can't cleanly
+# uninstall it here (rm'ing the symlink would corrupt brew's state) — flag it.
+if [ "$HAVE_BREW" -eq 0 ]; then
+  for prefix in /opt/homebrew /usr/local; do
+    if [ -e "$prefix/bin/cvm" ]; then
+      warn "found $prefix/bin/cvm but 'brew' is not on PATH — run 'brew uninstall cvm' to remove it cleanly."
+    fi
+  done
 fi
 
 if [ "$DRY" -eq 0 ] && command -v cvm >/dev/null 2>&1; then

--- a/verify-uninstall.sh
+++ b/verify-uninstall.sh
@@ -42,15 +42,26 @@ for p in "$CVM_HOME/state.json" "$CVM_HOME/vanilla" "$CVM_HOME/profiles"; do
 done
 [ -d "$CVM_HOME" ] && note "~/.cvm still exists (expected if shared with other tooling)"
 
-# --- Check 2: binary gone, every install method ---
+# --- Check 2: binary gone, every install method (PATH-independent where possible) ---
 if [ -e "$INSTALL_BIN" ]; then fail "binary still at $INSTALL_BIN"; else pass "no binary at install.sh path"; fi
+
+# Homebrew: probe known prefixes directly. In a non-login/non-interactive shell
+# brew's shellenv may not be sourced, so a PATH-only check would certify "clean"
+# while /opt/homebrew/bin/cvm is still installed — a dangerous false negative.
+brew_hit=0
+for prefix in /opt/homebrew /usr/local "$(brew --prefix 2>/dev/null || true)"; do
+  [ -n "$prefix" ] || continue
+  [ -e "$prefix/bin/cvm" ] && { fail "cvm binary still present at $prefix/bin/cvm"; brew_hit=1; }
+done
 if command -v brew >/dev/null 2>&1 && brew list cvm >/dev/null 2>&1; then
-  fail "cvm still installed via Homebrew (brew uninstall cvm)"
-else
-  pass "not brew-managed"
+  fail "cvm still installed via Homebrew (brew uninstall cvm)"; brew_hit=1
 fi
-if command -v go >/dev/null 2>&1 && [ -e "$(go env GOPATH 2>/dev/null)/bin/cvm" ]; then
-  fail "cvm still present in GOPATH/bin"
+[ "$brew_hit" -eq 0 ] && pass "not brew-managed"
+
+gp="$(go env GOPATH 2>/dev/null || true)"
+[ -n "$gp" ] || gp="${HOME}/go"   # Go's default when GOPATH is unset / go not on PATH
+if [ -e "$gp/bin/cvm" ]; then
+  fail "cvm still present in $gp/bin"
 else
   pass "no cvm in GOPATH/bin"
 fi
@@ -76,6 +87,13 @@ check_dir() {
       fi
       local_fail=1
     fi
+  done
+  # Orphaned temp dirs from a crashed materialization (uninstall.sh's recovery
+  # trap should have cleaned these, but flag them if a run died hard).
+  for t in "$dir"/*.cvm-uninstall.*; do
+    [ -e "$t" ] || continue
+    fail "$label: orphaned materialization temp left behind: $t"
+    local_fail=1
   done
   [ "$local_fail" -eq 0 ] && pass "$label: managed items are real files / absent (no symlinks)"
 }

--- a/verify-uninstall.sh
+++ b/verify-uninstall.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# verify-uninstall.sh — validates that cvm was uninstalled cleanly.
+#
+# Post-uninstall invariants:
+#   1. cvm's own artifacts are gone: ~/.cvm/state.json, ~/.cvm/vanilla,
+#      ~/.cvm/profiles. (~/.cvm itself may legitimately remain — it can be
+#      shared with other tooling — so we do NOT require it to be absent.)
+#   2. No cvm binary is resolvable: not on PATH, not at the install.sh path,
+#      not brew-managed, not in GOPATH/bin.
+#   3. No harness target dir contains a symlink for a managed item. After a
+#      clean uninstall every managed item is either absent or a REAL file/dir
+#      (the materialized active-profile config). A leftover symlink means a
+#      cvm link survived; a dangling one means data was lost.
+#
+# Exit 0 = clean, non-zero = something is still off. Read-only; safe anytime.
+set -eu
+
+CVM_HOME="${HOME}/.cvm"
+INSTALL_BIN="${HOME}/.local/bin/cvm"
+
+CLAUDE_DIR="${HOME}/.claude"
+CODEX_DIR="${CODEX_HOME:-${HOME}/.codex}"
+OPENCODE_DIR="${OPENCODE_CONFIG_DIR:-${HOME}/.config/opencode}"
+
+CLAUDE_ITEMS="CLAUDE.md settings.json settings.local.json keybindings.json statusline-command.sh commands skills agents hooks rules output-styles teams"
+CODEX_ITEMS="AGENTS.md"
+OPENCODE_ITEMS="AGENTS.md opencode.json skills agents commands plugin plugins"
+
+if [ -t 1 ]; then
+  GREEN=$(printf '\033[32m'); RED=$(printf '\033[31m'); YEL=$(printf '\033[33m'); RST=$(printf '\033[0m')
+else
+  GREEN=; RED=; YEL=; RST=
+fi
+FAILS=0
+pass() { printf '%s  ok %s %s\n' "$GREEN" "$RST" "$1"; }
+fail() { printf '%s fail%s %s\n' "$RED" "$RST" "$1"; FAILS=$((FAILS + 1)); }
+note() { printf '%s note%s %s\n' "$YEL" "$RST" "$1"; }
+
+# --- Check 1: cvm artifacts removed ---
+for p in "$CVM_HOME/state.json" "$CVM_HOME/vanilla" "$CVM_HOME/profiles"; do
+  if [ -e "$p" ]; then fail "cvm artifact still present: $p"; else pass "removed: $p"; fi
+done
+[ -d "$CVM_HOME" ] && note "~/.cvm still exists (expected if shared with other tooling)"
+
+# --- Check 2: binary gone, every install method ---
+if [ -e "$INSTALL_BIN" ]; then fail "binary still at $INSTALL_BIN"; else pass "no binary at install.sh path"; fi
+if command -v brew >/dev/null 2>&1 && brew list cvm >/dev/null 2>&1; then
+  fail "cvm still installed via Homebrew (brew uninstall cvm)"
+else
+  pass "not brew-managed"
+fi
+if command -v go >/dev/null 2>&1 && [ -e "$(go env GOPATH 2>/dev/null)/bin/cvm" ]; then
+  fail "cvm still present in GOPATH/bin"
+else
+  pass "no cvm in GOPATH/bin"
+fi
+if command -v cvm >/dev/null 2>&1; then
+  fail "a 'cvm' is still on PATH at $(command -v cvm)"
+else
+  pass "no cvm on PATH"
+fi
+
+# --- Check 3: no leftover symlinks among managed items ---
+check_dir() {
+  dir=$1; items=$2; label=$3
+  [ -d "$dir" ] || { pass "$label dir absent ($dir)"; return; }
+  local_fail=0
+  for item in $items; do
+    path="$dir/$item"
+    if [ -L "$path" ]; then
+      target=$(readlink "$path" 2>/dev/null || echo "?")
+      if [ -e "$path" ]; then
+        fail "$label: leftover symlink (should be a real file) $path -> $target"
+      else
+        fail "$label: dangling symlink (data lost) $path -> $target"
+      fi
+      local_fail=1
+    fi
+  done
+  [ "$local_fail" -eq 0 ] && pass "$label: managed items are real files / absent (no symlinks)"
+}
+check_dir "$CLAUDE_DIR" "$CLAUDE_ITEMS" "claude"
+check_dir "$CODEX_DIR" "$CODEX_ITEMS" "codex"
+check_dir "$OPENCODE_DIR" "$OPENCODE_ITEMS" "opencode"
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+  printf '%sAll checks passed — cvm is uninstalled cleanly.%s\n' "$GREEN" "$RST"
+  exit 0
+else
+  printf '%s%d check(s) failed.%s\n' "$RED" "$FAILS" "$RST"
+  exit 1
+fi


### PR DESCRIPTION
## Qué

Agrega un script para desinstalar cvm de forma limpia (`uninstall.sh`) y un script de validación (`verify-uninstall.sh`).

## Por qué

cvm activa un profile creando **symlinks** desde el repo del profile hacia los target dirs de cada harness (`~/.claude`, `~/.codex`, `~/.config/opencode`). Un uninstall ingenuo (`rm -rf ~/.cvm`) dejaría esos symlinks colgados y se perdería la config que el usuario está usando. Además, en la práctica `~/.cvm` puede estar **compartido** con otra herramienta, así que borrarlo entero es peligroso.

## Cómo

`uninstall.sh` corre en 4 pasos ordenados para no perder nada:

1. **Materializar** — reemplaza cada symlink gestionado por cvm en los target dirs por una **copia real dereferenciada** (`cp -RL`). La config del profile activo queda congelada como archivos reales, desacoplada de cvm y del repo. Los archivos reales del usuario no se tocan.
2. **Backup** — tar.gz de los artefactos propios de cvm (`state.json`, `vanilla/`, `profiles/`) en `~/cvm-backup-<ts>.tar.gz`.
3. **Remover** — borra **quirúrgicamente** sólo esos tres artefactos (nunca `~/.cvm` entero) y el binario, detectando los métodos de instalación: Homebrew, `~/.local/bin` (install.sh) y `GOPATH/bin` (go install).
4. **Verificar** — corre `verify-uninstall.sh`.

`verify-uninstall.sh` valida el estado limpio (read-only): artefactos de cvm borrados, binario no resoluble por ningún método, y cero symlinks residuales/colgados entre los managed items.

Ninguno de los dos scripts depende del binario `cvm`, así que funcionan aunque esté roto.

Flags de `uninstall.sh`: `--dry-run`, `--yes`, `--no-backup`.

## Testing

- `sh -n` en ambos scripts (sintaxis OK).
- `--dry-run` contra una instalación real (brew + go bin + profile `scratch` activo).
- Test end-to-end en sandbox aislado (HOME falso, PATH controlado): materialización con contenido correcto, archivos de usuario intactos, data no-cvm preservada, backup completo, desacople real verificado (borrar el source no afecta la config materializada), y `verify-uninstall.sh` pasa todos los checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)